### PR TITLE
add latexmk -pvc feature and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,19 @@ TEX_DIR = tex
 BIB_DIR = bib
 
 # Option for latexmk
-LATEXMK_OPT = -xelatex -gg -silent -f
+LATEXMK_OPT_BASE = -xelatex -gg -silent
+LATEXMK_OPT = $(LATEXMK_OPT_BASE) -f
+LATEXMK_OPT_PVC = $(LATEXMK_OPT_BASE) -pvc
 
 all: $(THESIS).pdf
 
-.PHONY : all clean validate view wordcount git
+.PHONY : all clean pvc validate view wordcount git
 
 $(THESIS).pdf : $(THESIS).tex $(TEX_DIR)/*.tex $(BIB_DIR)/*.bib sjtuthesis.cls sjtuthesis.cfg Makefile
 	-latexmk $(LATEXMK_OPT) $(THESIS)
+
+pvc :
+	latexmk $(LATEXMK_OPT_PVC) $(THESIS)
 
 validate :
 	xelatex -no-pdf -halt-on-error $(THESIS)

--- a/README.md
+++ b/README.md
@@ -1,86 +1,122 @@
-What is SJTUThesis?
-======
+# What is SJTUThesis?
 
-SJTUThesis is an *unofficial* XeLaTeX template for preparing bachelor, master, or doctor thesis in Shanghai Jiao Tong University.
+SJTUThesis is an *unofficial* XeLaTeX template for preparing bachelor, master, or doctor thesis in Shanghai Jiao Tong University. 
 
-上海交通大学学位论文模板
-======
+# 上海交通大学学位论文模板
 
-这是为撰写上海交通大学学士、硕士或博士论文而准备的XeLaTeX模板，非官方出品。生成的学位论文文件参见[README.pdf][README]。
+这是为撰写上海交通大学学士、硕士或博士论文而准备的 XeLaTeX 模板，非官方出品。生成的学位论文文件参见 [README.pdf][README]。
 
-如何使用
-------
+## 如何使用
 
 ### 系统需求
 
-* 支持XeTeX的**完整**TeX发行版。2015年的[TeXLive](https://www.tug.org/texlive/)和[MacTeX](https://www.tug.org/mactex/)发行版都能编译此模板。
-* TeX Gyre Font西文字体和Adobe四款中文字体：AdobeSongStd、AdobeKaitiStd、AdobeHeitiStd、AdobeFangsongStd。
-* Windows用户请使用[Cygwin](http://cygwin.com)安装如下工具：git(版本控制)、GNUmake(编译控制)、perl(字数统计)。
+#### TeX 发行版
+
+支持 XeTeX 的**完整** TeX 发行版。2013/2014/2015年的 [TeXLive](https://www.tug.org/texlive/) 和 [MacTeX](https://www.tug.org/mactex/) 发行版都能编译此模板。据不完全统计，Windows 下的 CTeX(2.9.2) 也能顺利编译此模板。
+
+以 TexLive/MacTeX 为例，根据你使用的发行版和宏包版本，你需要使用以下不同的分支：
+
+- 2015 年的发行版：使用 [master(v0.9)](https://github.com/weijianwen/SJTUThesis/tree/master) 分支。
+- 2014 年的发行版：建议使用 [v0.8](https://github.com/weijianwen/SJTUThesis/tree/v0.8) 分支。
+- 2013 年的发行版：建议使用 [v0.7](https://github.com/weijianwen/SJTUThesis/tree/v0.7) 分支。
+
+**Windows用户**请使用 [Babun](http://babun.github.io/) 作为命令行终端。Babun 已默认安装有这些工具：git(版本控制)、GNUmake(编译控制)、perl(字数统计)。
+
+#### 字体
+
+中英文分别依赖 Adobe 的四套简体中文字体和 TeX Gyre Termes 西文字体。Adobe 的四套字体可以从 [GitCafe](https://gitcafe.com/billryan/resume/tree/zh_CN/fonts/zh_CN-Adobe) 或者 [GitHub](https://github.com/billryan/resume/tree/zh_CN/fonts/zh_CN-Adobe) 处下载。Tex Gyre Termes 则可以从 [CTAN](http://www.ctan.org/tex-archive/fonts/tex-gyre/fonts/opentype/public/tex-gyre) 中下载，共有 regular, bold, bolditalic, italic 四种不同的字型需要下载，四种字型的打包下载见 [这里](http://7xojrx.com1.z0.glb.clouddn.com/docs/TeX-Gyre-Termes.zip)。字体的安装双击即可，Linux 下可能需要刷新下字体缓存。
+
+对中文字体的一点说明：Windows 下如果使用 Word 进行排版的话，中文衬线字体使用的一般是俗称「宋体」的「中易宋体」。实际上对于印刷体来说，Adobe 家的四款中文字体 AdobeSongStd, AdobeKaitiStd, AdobeHeitiStd, AdobeFangsongStd 效果更好，因此在绝大多数高校学位论文模板中默认使用这四套中文字体编译生成 PDF。
 
 ### 获取模板
 
-直接下载[最新版模板](https://github.com/weijianwen/SJTUThesis/archive/master.zip)：
+根据「系统需求」中情形选择适合你系统情况的分支，然后根据情况选择 git 克隆或者下载 GitHub 上的压缩包。尽管下载压缩包的方式简单粗暴，但为了能使用模板的最新功能，还是大力推荐终端中克隆的方式。不熟悉命令行没有关系，下文将详述方法。
 
-	$ wget https://github.com/weijianwen/SJTUThesis/archive/master.zip
+#### 终端中克隆
 
-也可以从github克隆最新版模板：
+打开终端，OS X 用户需要在 spotlight 中搜索`terminal`, Windows 用户则使用前文推荐的 Babun. 在终端下按如下步骤操作。
+友情提示：Windows 下的 Babun 默认使用鼠标右键作为终端中的粘贴功能。
 
-	$ git clone https://github.com/weijianwen/SJTUThesis.git
+```bash
+cd
+git clone https://github.com/weijianwen/SJTUThesis.git
+```
 
-或者是将本地模板更新到最新版
+如果之前有克隆过此模板但是想与 GitHub 上的最新版本同步，以`master`分支为例，执行以下命令更新到最新版。
+```
+git pull origin master
+```
+若是自己 fork 后克隆下来的，则执行以下命令。
+```
+git pull upstream master
+```
 
-	$ git pull upstream master
+#### 压缩包下载
+
+- 2015 年的发行版：使用 [master(v0.9)](https://github.com/weijianwen/SJTUThesis/archive/master.zip) 分支。
+- 2014 年的发行版：建议使用 [v0.8](https://github.com/weijianwen/SJTUThesis/archive/v0.8.zip) 分支。
+- 2013 年的发行版：建议使用 [v0.7](https://github.com/weijianwen/SJTUThesis/archive/v0.7.zip) 分支。
 
 ### 编译模板
 
-编译模板，生成学位论文PDF文件。GNUMake将调用```latexmk```程序，自动完成模板的多轮编译。
+编译模板，生成学位论文PDF文件。GNUMake将调用`latexmk`程序，自动完成模板的多轮编译。平时写论文时推荐使用`make pvc`达到「持续集成」——持续监听文件改动，用户无需操心后台编译的问题，编译好后会自动打开 PDF 文档，这个特性在没定稿之前非常方便！由于 CTeX 下的 Miktex `latexmk` 有可能有问题，故还是推荐 Windows 用户使用 TeXLive 发行版试试看。
 
-	$ make clean thesis.pdf
+由于`latexmk -pvc`默认使用系统默认的 PDF 打开程序，你可以对这一行为进行定制，从而可使用专门的 PDF 阅读器来预览学位论文。以 OS X 下的 Skim 阅读器为例，执行以下命令即可。
 
-若需要生成用于提交盲审的论文(隐去作者、导师等信息)，可在```thesis.tex```中为```sjtuthesis```文档类添加```review```选项。 若需要生成包含“原创性声明扫描件”和“授权书”签名扫描件的学位论文，请将扫描件分别保存为```pdf/origignal.pdf```和```pdf/authorization.pdf```，然后添加```submit```选项重新编译模板。
+```
+wget http://7xojrx.com1.z0.glb.clouddn.com/docs/latexmkrc -O ~/.latexmkrc
+make pvc
+```
+
+如果最终定稿，则使用以下命令编译。
+
+```
+$ make clean thesis.pdf
+```
+
+若需要生成用于提交盲审的论文(隐去作者、导师等信息)，可在`thesis.tex`中为`sjtuthesis`文档类添加`review`选项。 若需要生成包含“原创性声明扫描件”和“授权书”签名扫描件的学位论文，请将扫描件分别保存为`pdf/origignal.pdf`和`pdf/authorization.pdf`，然后添加`submit`选项重新编译模板。
 
 #### Windows用户编译
 
-双击`compile.bat`即可完成编译过程，生成`thesis.pdf`，不依赖于GNUMake。
+双击`compile.bat`即可完成编译过程，生成`thesis.pdf`，不依赖于 GNUMake。
 
 ### 字数统计
 
-	$ make wordcount	
+```
+make wordcount
+```
 
 ### 问题诊断
 
 编译失败时，可以尝试手动逐次编译。
-结合文档[README.pdf][README]中的说明，有助于定位故障。
+结合文档 [README.pdf][README] 中的说明，有助于定位故障。
+```
+$ xelatex -no-pdf thesis
+$ biber --debug thesis
+$ xelatex thesis
+$ xelatex thesis
+```
 
-	$ xelatex -no-pdf thesis
-	$ biber --debug thesis
-	$ xelatex thesis
-	$ xelatex thesis
-
-反馈问题
-------
+## 反馈问题
 
 建议以如下的顺序反馈使用问题：
 
-* [在github项目主页开issue](https://github.com/weijianwen/sjtu-thesis-template-latex/issues)
-* [在水源BBS TeX_LaTeX版发帖](https://bbs.sjtu.edu.cn/bbsdoc?board=TeX_LaTeX)
+* [在 GitHub 项目主页开 issue](https://github.com/weijianwen/sjtu-thesis-template-latex/issues)
+* [在水源 BBS TeX_LaTeX 版发帖](https://bbs.sjtu.edu.cn/bbsdoc?board=TeX_LaTeX)
 
-后续工作计划
-------
+## 后续工作计划
 
 * 精简代码；
 * 改进开章页设计；
 
-所有版本
-------
+## 所有版本
 
 * [v 0.9](https://github.com/weijianwen/SJTUThesis/tree/v0.9): 当前master分支，适配ctex 2.x宏包，需要使用2015年的TeX发行版，无法使用更早的发行版编译。
 * [v 0.8](https://github.com/weijianwen/SJTUThesis/tree/v0.8)：使用biber/biblatex处理参考文献，需要使用2014的TeX发行版，无法使用2013年和2015年的TeX发行版编译。
 * [v 0.7](https://github.com/weijianwen/SJTUThesis/tree/v0.7)：使用bibex处理参考文献（会产生错误信息，可忽略），需要使用2013或2014年的TeX发行版，无法使用2015年的TeX发行版编译。
 
-软件许可证
-------
+## 软件许可证
 
-上海交通大学校徽图片(```sjtulog.png```)和横幅图片(```sjtubanner.png```)的版权归原作者所有。其他部分使用[Apache License 2.0](LICENSE)授权。
+上海交通大学校徽图片(`sjtulog.png`)和横幅图片(`sjtubanner.png`)的版权归原作者所有。其他部分使用 [Apache License 2.0](LICENSE) 授权。
 
 [README]: https://s3.amazonaws.com/sjtuthesis/README.pdf


### PR DESCRIPTION
1. Makefile 中增加 `latexmk -pvc` 增强实用性。
2. README 中英文和中文空一格看起来更美观。
3. README 中使用 Babun 替代 Cygwin, Babun 基于 Cygwin，开箱即用，省去了麻烦的配置工作。
4. 增加了字体下载安装说明，我发现周围很多同学都不知道怎么下到需要的字体。
5. 统一了 README 中的一些 markdown 语法。
