### PR TITLE
fix typo 代码索引 -> 算法索引

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -55,7 +55,7 @@
 \listoftables
 \addcontentsline{toc}{chapter}{\listtablename}  %将表格目录加入全文目录
 % \listofalgorithms
-% \addcontentsline{toc}{chapter}{代码索引}  %将表格目录加入全文目录
+% \addcontentsline{toc}{chapter}{算法索引}        %将算法目录加入全文目录
 
 \include{tex/symbol} % 主要符号、缩略词对照表
 


### PR DESCRIPTION
目录中应为“算法索引”，与算法索引的页面标题保持一致。
