### PR TITLE
`lstlisting` 采用等宽字体。

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -194,7 +194,7 @@
   numbers=left,%左侧显示行号
   stepnumber=1,%
   numberstyle=\tiny, %行号字体用小号
-  basicstyle=\footnotesize, %
+  basicstyle={\footnotesize\ttfamily}, %
   showspaces=false, %
   flexiblecolumns=true, %
   breaklines=true, %对过长的代码自动换行


### PR DESCRIPTION
我不确定这是个 bug 还是只有我这里存在该问题：在我这边使用原有的 `lstlisting` 包围的代码在编译出来后不是等宽的，本 PR 中的修改可以解决这个问题。
