### PR TITLE
修改模板中使用的字体 避免误判页数

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -4,8 +4,8 @@
 %%==================================================
 
 % 双面打印
-\documentclass[doctor, fontset=adobe, openrigh, twoside, zihao=-4]{sjtuthesis}
-% \documentclass[bachelor, fontset=adobe, openany, oneside, zihao=-4, submit]{sjtuthesis} 
+\documentclass[doctor, fontset=adobe, openrigh, twoside]{sjtuthesis}
+% \documentclass[bachelor, fontset=adobe, openany, oneside, submit]{sjtuthesis} 
 % \documentclass[master, adobefonts, review]{sjtuthesis} 
 % \documentclass[%
 %   bachelor|master|doctor,	% 必选项


### PR DESCRIPTION
- 本科生毕业论文模板里要求5号字体
- `thesis.tex` 中示例使用了4号字体`zihao=-4`，导致部分直接复制粘贴的同学严重误判论文页数

感谢@gaocegege提醒陶醉在论文页数中的我。
