### PR TITLE
使用 algorithmicx 代替 algorithmic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ README.pdf
 *.aux
 *.log
 *.lot
+*.loa
 *.out
 *.toc
 *.blg

--- a/compile.bat
+++ b/compile.bat
@@ -9,15 +9,15 @@ if exist thesis.pdf (
 
 echo Compile...
 echo xelatex -no-pdf thesis...
-xelatex -no-pdf thesis >nul
+xelatex -no-pdf thesis > nul
 echo biber --debug thesis...
-biber --debug thesis >nul
+biber --debug thesis > nul
 echo xelatex thesis...
-xelatex thesis >nul
-xelatex thesis >nul
+xelatex thesis > nul
+xelatex thesis > nul
 echo clean files...
-del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.alg *.glsdefs >nul 2>nul
+del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.loa *.alg *.glsdefs >nul 2>nul
 cd tex
-del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.alg *.glsdefs >nul 2>nul
+del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.loa *.alg *.glsdefs >nul 2>nul
 echo finish...
 pause

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -261,6 +261,34 @@
   \newtheorem{bcor}[thm]{\sjtu@label@cor~}
   \renewcommand{\proofname}{\bf\sjtu@label@proof}
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% The following definitions add Switch statement to LaTeX algorithmicx package
+% It's based on Werner's answer on stackoverflow
+% http://tex.stackexchange.com/questions/53357/switch-cases-in-algorithmic  
+
+% New definitions
+\algnewcommand\algorithmicswitch{\textbf{switch}}
+\algnewcommand\algorithmiccase{\textbf{case}}
+\algnewcommand\algorithmicdefault{\textbf{default}}
+
+% New "environments"
+% using \algtext*{<env>} removes any typesetting of that command
+\algdef{SE}[SWITCH]{Switch}{EndSwitch}[1]{\algorithmicswitch\ (#1)}{\algorithmicend\ \algorithmicswitch}%
+%\algtext*{EndSwitch}%
+\algdef{SE}[CASE]{Case}{EndCase}[1]{\algorithmiccase\ #1:}{\algorithmicend\ \algorithmiccase}%
+\algtext*{EndCase}%
+\algdef{SE}[DEFAULT]{Default}{EndDefault}{\algorithmicdefault\ :}{\algorithmicend\ \algorithmicdefault}%
+\algtext*{EndDefault}%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% The following add some extra commands to LaTeX algorithmicx package
+
+% Assert
+\algnewcommand\algorithmicassert{\texttt{assert}}
+\algnewcommand\Assert[1]{\State \algorithmicassert(#1)}%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 %==========
 % Segment 4. Draw the sjtuthesis
 %==========

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -71,7 +71,7 @@
 \RequirePackage[inline]{enumitem}
 \RequirePackage{pdfpages}
 \RequirePackage{calc}
-\RequirePackage{algorithm, algorithmic}
+\RequirePackage{algorithm, algorithmicx, algpseudocode}
 \RequirePackage{siunitx}
 \RequirePackage{tikz}
 \usetikzlibrary{shapes.geometric, arrows}
@@ -128,8 +128,11 @@
 \ctexset{listfigurename={\sjtu@listfigurename}}
 \ctexset{listtablename={\sjtu@listtablename}}
 \floatname{algorithm}{\sjtu@label@algo}
+\renewcommand{\algorithmicrequire}{\textbf{输入:}} 
+\renewcommand{\algorithmicensure}{\textbf{输出:}}
 \renewcommand{\listalgorithmname}{\sjtu@listalgorithmname}
 \renewcommand{\lstlistingname}{\sjtu@value@listingname}
+
 % Title Settings at the chapter Level
 \ctexset{chapter={
 	nameformat={\Large\bfseries},
@@ -257,26 +260,6 @@
   \newtheorem{bprop}[thm]{\sjtu@label@prop~}
   \newtheorem{bcor}[thm]{\sjtu@label@cor~}
   \renewcommand{\proofname}{\bf\sjtu@label@proof}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% The following definitions are to extend the LaTeX algorithmic 
-% package with SWITCH statements and one-line structures.
-% The extension is by 
-%   Prof. Farn Wang 
-%   Dept. of Electrical Engineering, 
-%   National Taiwan University. 
-% 
-\newcommand{\SWITCH}[1]{\STATE \textbf{switch} (#1)}
-\newcommand{\ENDSWITCH}{\STATE \textbf{end switch}}
-\newcommand{\CASE}[1]{\STATE \textbf{case} #1\textbf{:} \begin{ALC@g}}
-\newcommand{\ENDCASE}{\end{ALC@g}}
-\newcommand{\CASELINE}[1]{\STATE \textbf{case} #1\textbf{:} }
-\newcommand{\DEFAULT}{\STATE \textbf{default:} \begin{ALC@g}}
-\newcommand{\ENDDEFAULT}{\end{ALC@g}}
-\newcommand{\DEFAULTLINE}[1]{\STATE \textbf{default:} }
-% 
-% End of the LaTeX algorithmic package extension.
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %==========
 % Segment 4. Draw the sjtuthesis

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -384,8 +384,8 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 
 \begin{algorithm}
 % \begin{algorithm}[H] % 强制定位
-\label{algo:sum_100}
 \caption{求100以内的整数和}
+\label{algo:sum_100}
 \begin{algorithmic}[1] %每行显示行号
 \Ensure 100以内的整数和 % 输出
 \State $sum \gets 0$
@@ -415,8 +415,8 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 
 \begin{algorithm}
 % \begin{algorithm}[H] % 强制定位
-\label{algo:merge_sort}
 \caption{用归并排序求逆序数}
+\label{algo:merge_sort}
 \begin{algorithmic}[1] %每行显示行号
 \Require $Array$数组，$n$数组大小 % 输入
 \Ensure 逆序数 % 输出
@@ -468,3 +468,7 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 这是写在算法\ref{algo:merge_sort}后面的一段话，
 但是当算法\ref{algo:merge_sort}不使用\verb+\begin{algorithm}[H]+时它会出现在算法\ref{algo:merge_sort}
 甚至算法\ref{algo:sum_100}前面。
+
+对于算法的索引要注意\verb+\caption+和\verb+\label+的位置, 
+必须是先\verb+\caption+再\verb+\label+\footnote{http://tex.stackexchange.com/questions/65993/algorithm-numbering}，
+否则会出现\verb+\ref{algo:sum_100}+生成的编号跟对应算法上显示不一致的问题。

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -370,45 +370,62 @@ int main() {
 }
 \end{lstlisting}
 
-\section{用algorithm和algorithmic宏包插入算法描述}
+\section{用algorithm和algorithmicx宏包插入算法描述}
 
-如算法\ref{algo:sum_I_want}所示。
+algorithmicx 比 algorithmic 增加了一些命令。
+示例如\ref{algo:merge_sort}，示例代码来自\href{http://hustsxh.is-programmer.com/posts/38801.html}{xhSong的博客}。
+详细的使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/latex/contrib/algorithmicx/algorithmicx.pdf}{官方README}。
 
-\begin{algorithm}
-\caption{求和算法}
-\label{algo:sum_I_want}
-\begin{algorithmic}
-\REQUIRE $n \geq 1$                  %输入条件
-\ENSURE $Sum = 1 + \cdots + n$       %输出
-\STATE $Sum \leftarrow 0$            %\STATE 命名演示
-\IF {$n < 1$}                        %条件语句
-\PRINT {Input Error}                 %打印语句
-\ENDIF
-\RETURN Sum
-\end{algorithmic}
-\end{algorithm}
+总结一些注意事项：
 
-王凡教授\footnote{\url{http://cc.ee.ntu.edu.tw/~farn/}}对algorithmic做了扩展，支持\verb+STATE+、\verb+SWITCH+和\verb+CASE+等语句。
+\begin{itemize}
+  \item 
+  部分情况下，浮动时会出现图片出现在算法中间的情况。
+  参考
+  \href{http://tex.stackexchange.com/questions/165021/fixing-the-location-of-the-appearance-in-algorithmicx-environment}{这个问题}
+  使用H来强制定位，不允许浮动。
+\end{itemize}
 
 \begin{algorithm}
-\caption{fibonacci}
-\label{algo: Fibonacci Sequence}
-\begin{algorithmic}
-\REQUIRE $num$
-
-\STATE $res \leftarrow 0$
-\SWITCH {$num$}
-  \CASE {$0$}
-    \STATE $res \leftarrow 1$
-  \ENDCASE
-  \CASE {$1$}
-    \STATE $res \leftarrow 1$
-  \ENDCASE
-  \DEFAULT
-    \STATE $res \leftarrow fibonacci(num-1) + fibonacci(num-2)$
-  \ENDDEFAULT
-\ENDSWITCH
-
-\RETURN $res$
+\label{algo:merge_sort}
+\caption{用归并排序求逆序数}
+\begin{algorithmic}[1] %每行显示行号
+\Require $Array$数组，$n$数组大小
+\Ensure 逆序数
+\Function {MergerSort}{$Array, left, right$}
+  \State $result \gets 0$
+  \If {$left < right$}
+    \State $middle \gets (left + right) / 2$
+    \State $result \gets result +$ \Call{MergerSort}{$Array, left, middle$}
+    \State $result \gets result +$ \Call{MergerSort}{$Array, middle, right$}
+    \State $result \gets result +$ \Call{Merger}{$Array,left,middle,right$}
+  \EndIf
+  \State \Return{$result$}
+\EndFunction
+\State %空一行
+\Function{Merger}{$Array, left, middle, right$}
+  \State $i\gets left$
+  \State $j\gets middle$
+  \State $k\gets 0$
+  \State $result \gets 0$
+  \While{$i<middle$ \textbf{and} $j<right$}
+    \If{$Array[i]<Array[j]$}
+      \State $B[k++]\gets Array[i++]$
+    \Else
+      \State $B[k++] \gets Array[j++]$
+      \State $result \gets result + (middle - i)$
+    \EndIf
+  \EndWhile
+  \While{$i<middle$}
+    \State $B[k++] \gets Array[i++]$
+  \EndWhile
+  \While{$j<right$}
+    \State $B[k++] \gets Array[j++]$
+  \EndWhile
+  \For{$i = 0 \to k-1$}
+    \State $Array[left + i] \gets B[i]$
+  \EndFor
+  \State \Return{$result$}
+\EndFunction
 \end{algorithmic}
 \end{algorithm}

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -472,3 +472,24 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 对于算法的索引要注意\verb+\caption+和\verb+\label+的位置, 
 必须是先\verb+\caption+再\verb+\label+\footnote{http://tex.stackexchange.com/questions/65993/algorithm-numbering}，
 否则会出现\verb+\ref{algo:sum_100}+生成的编号跟对应算法上显示不一致的问题。
+
+根据Werner的回答\footnote{http://tex.stackexchange.com/questions/53357/switch-cases-in-algorithmic}
+增加了\verb+Switch+和\verb+Case+的支持，见算法\ref{algo:switch_example}。
+
+\begin{algorithm}
+\caption{Switch示例}
+\label{algo:switch_example}
+\begin{algorithmic}[1]
+  \Switch{$s$}
+    \Case{$a$}
+      \Assert{0}
+    \EndCase
+    \Case{$b$}
+      \Assert{1}
+    \EndCase
+    \Default
+      \Assert{2}
+    \EndDefault
+  \EndSwitch
+\end{algorithmic}
+\end{algorithm}

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -376,15 +376,18 @@ algorithmicx 比 algorithmic 增加了一些命令。
 示例如算法\ref{algo:sum_100}和算法\ref{algo:merge_sort}，
 后者的代码来自\href{http://hustsxh.is-programmer.com/posts/38801.html}{xhSong的博客}。
 algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/latex/contrib/algorithmicx/algorithmicx.pdf}{官方README}。
-使用算法宏包时，算法出现的位置不一定按照tex文件里的书写顺序。
+使用算法宏包时，算法出现的位置很多时候不按照tex文件里的书写顺序, 
+需要强制定位时可以使用\verb+\begin{algorithm}[H]+
+\footnote{http://tex.stackexchange.com/questions/165021/fixing-the-location-of-the-appearance-in-algorithmicx-environment}
 
-这是写在第一个算法前面的一段话，它一般会出现在算法前面。
+这是写在算法\ref{algo:sum_100}前面的一段话，在生成的文件里它会出现在算法\ref{algo:sum_100}前面。
 
 \begin{algorithm}
+% \begin{algorithm}[H] % 强制定位
 \label{algo:sum_100}
 \caption{求100以内的整数和}
-\begin{algorithmic}
-\Ensure 100以内的整数和
+\begin{algorithmic}[1] %每行显示行号
+\Ensure 100以内的整数和 % 输出
 \State $sum \gets 0$
 \For{$i = 0 \to 100$}
     \State $sum \gets sum + i$
@@ -392,15 +395,31 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 \end{algorithmic}
 \end{algorithm}
 
-这是写在两个算法中间的一段话，但是它有可能出现在第一个算法前面。
+这是写在两个算法中间的一段话，当算法\ref{algo:sum_100}不使用\verb+\begin{algorithm}[H]+时它也会出现在算法\ref{algo:sum_100}前面。
+
+对于很长的算法，单一的算法块\verb+\begin{algorithm}...\end{algorithm}+是不能自动跨页的
+\footnote{http://tex.stackexchange.com/questions/70733/latex-algorithm-not-display-under-correct-section}，
+会出现的情况有：
+
+\begin{itemize}
+  \item 该页放不下当前的算法，留下大片空白，算法在下一页显示
+  \item 单一页面放不下当前的算法，显示时超过页码的位置直到超出整个页面范围
+\end{itemize}
+
+解决方法有：
+
+\begin{itemize}
+  \item (推荐)使用\verb+algstore{algname}+和\verb+algrestore{algname}+来讲算法分为两个部分\footnote{http://tex.stackexchange.com/questions/29816/algorithm-over-2-pages}，如算法\ref{algo:merge_sort}。
+  \item 人工拆分算法为多个小的部分。
+\end{itemize}
 
 \begin{algorithm}
 % \begin{algorithm}[H] % 强制定位
 \label{algo:merge_sort}
 \caption{用归并排序求逆序数}
 \begin{algorithmic}[1] %每行显示行号
-\Require $Array$数组，$n$数组大小
-\Ensure 逆序数
+\Require $Array$数组，$n$数组大小 % 输入
+\Ensure 逆序数 % 输出
 \Function {MergerSort}{$Array, left, right$}
   \State $result \gets 0$
   \If {$left < right$}
@@ -446,15 +465,6 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
 \end{algorithmic}
 \end{algorithm}
 
-这是写在第二个算法后面的一段话，但是它很有可能出现在第二个算法前面。
-
-总结一些注意事项：
-
-\begin{itemize}
-  \item 
-  部分情况下，浮动时会出现图片出现在算法中间的情况。
-  参考
-  \href{http://tex.stackexchange.com/questions/165021/fixing-the-location-of-the-appearance-in-algorithmicx-environment}{这个问题}
-  使用H来强制定位，不允许浮动，但是会有明显的副作用。
-  \item 算法过长时会出现显示问题，比如\ref{algo:merge_sort}超过了单页的长度，可以改小字体或者分成多个小的算法来解决。
-\end{itemize}
+这是写在算法\ref{algo:merge_sort}后面的一段话，
+但是当算法\ref{algo:merge_sort}不使用\verb+\begin{algorithm}[H]+时它会出现在算法\ref{algo:merge_sort}
+甚至算法\ref{algo:sum_100}前面。

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -425,6 +425,13 @@ algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/
       \State $result \gets result + (middle - i)$
     \EndIf
   \EndWhile
+  \algstore{MergeSort}
+\end{algorithmic}
+\end{algorithm}
+
+\begin{algorithm}
+\begin{algorithmic}[1]
+  \algrestore{MergeSort}
   \While{$i<middle$}
     \State $B[k++] \gets Array[i++]$
   \EndWhile

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -373,20 +373,29 @@ int main() {
 \section{用algorithm和algorithmicx宏包插入算法描述}
 
 algorithmicx 比 algorithmic 增加了一些命令。
-示例如\ref{algo:merge_sort}，示例代码来自\href{http://hustsxh.is-programmer.com/posts/38801.html}{xhSong的博客}。
-详细的使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/latex/contrib/algorithmicx/algorithmicx.pdf}{官方README}。
+示例如算法\ref{algo:sum_100}和算法\ref{algo:merge_sort}，
+后者的代码来自\href{http://hustsxh.is-programmer.com/posts/38801.html}{xhSong的博客}。
+algorithmicx的详细使用方法见\href{http://mirror.hust.edu.cn/CTAN/macros/latex/contrib/algorithmicx/algorithmicx.pdf}{官方README}。
+使用算法宏包时，算法出现的位置不一定按照tex文件里的书写顺序。
 
-总结一些注意事项：
-
-\begin{itemize}
-  \item 
-  部分情况下，浮动时会出现图片出现在算法中间的情况。
-  参考
-  \href{http://tex.stackexchange.com/questions/165021/fixing-the-location-of-the-appearance-in-algorithmicx-environment}{这个问题}
-  使用H来强制定位，不允许浮动。
-\end{itemize}
+这是写在第一个算法前面的一段话，它一般会出现在算法前面。
 
 \begin{algorithm}
+\label{algo:sum_100}
+\caption{求100以内的整数和}
+\begin{algorithmic}
+\Ensure 100以内的整数和
+\State $sum \gets 0$
+\For{$i = 0 \to 100$}
+    \State $sum \gets sum + i$
+  \EndFor
+\end{algorithmic}
+\end{algorithm}
+
+这是写在两个算法中间的一段话，但是它有可能出现在第一个算法前面。
+
+\begin{algorithm}
+% \begin{algorithm}[H] % 强制定位
 \label{algo:merge_sort}
 \caption{用归并排序求逆序数}
 \begin{algorithmic}[1] %每行显示行号
@@ -429,3 +438,16 @@ algorithmicx 比 algorithmic 增加了一些命令。
 \EndFunction
 \end{algorithmic}
 \end{algorithm}
+
+这是写在第二个算法后面的一段话，但是它很有可能出现在第二个算法前面。
+
+总结一些注意事项：
+
+\begin{itemize}
+  \item 
+  部分情况下，浮动时会出现图片出现在算法中间的情况。
+  参考
+  \href{http://tex.stackexchange.com/questions/165021/fixing-the-location-of-the-appearance-in-algorithmicx-environment}{这个问题}
+  使用H来强制定位，不允许浮动，但是会有明显的副作用。
+  \item 算法过长时会出现显示问题，比如\ref{algo:merge_sort}超过了单页的长度，可以改小字体或者分成多个小的算法来解决。
+\end{itemize}

--- a/thesis.tex
+++ b/thesis.tex
@@ -54,8 +54,8 @@
 \addcontentsline{toc}{chapter}{\listfigurename} %将插图目录加入全文目录
 \listoftables
 \addcontentsline{toc}{chapter}{\listtablename}  %将表格目录加入全文目录
-% \listofalgorithms
-% \addcontentsline{toc}{chapter}{算法索引}        %将算法目录加入全文目录
+\listofalgorithms
+\addcontentsline{toc}{chapter}{算法索引}        %将算法目录加入全文目录
 
 \include{tex/symbol} % 主要符号、缩略词对照表
 


### PR DESCRIPTION
示例 [sjtu_thesis_algorithmicx.pdf](https://github.com/weijianwen/SJTUThesis/files/285782/sjtu_thesis_algorithmicx.pdf)

对应issue #145 
- 替换了宏包
- 默认启用算法索引, 更新了 gitignore 和 win 下的 compile.bat
- 移除了旧的example
- 移除了SWITCH的扩展和示例
