### PR TITLE
windows batch output stderr during compilation

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -9,12 +9,12 @@ if exist thesis.pdf (
 
 echo Compile...
 echo xelatex -no-pdf thesis...
-xelatex -no-pdf thesis > nul
+xelatex -no-pdf thesis 1> nul
 echo biber --debug thesis...
-biber --debug thesis > nul
+biber --debug thesis 1> nul
 echo xelatex thesis...
-xelatex thesis > nul
-xelatex thesis > nul
+xelatex thesis 1> nul
+xelatex thesis 1> nul
 echo clean files...
 del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.loa *.alg *.glsdefs >nul 2>nul
 cd tex


### PR DESCRIPTION
enable stderr output to the screen so that compilation errors could be located easier, older version of windows compilation batch redirects all outputs to `null`.