### PR TITLE
在bookmark中加入中英文摘要两项

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -500,12 +500,16 @@
 \fi
 
 % 中英文摘要
-\newenvironment{abstract}{\chapter*{\sjtu@value@title\vskip 20pt\sjtu@label@abstract}\markboth{\sjtu@label@abstract}{}}{}
+\newenvironment{abstract}{\cleardoublepage \pdfbookmark[0]{\sjtu@label@abstract}{abstract}
+\chapter*{\sjtu@value@title\vskip 20pt\sjtu@label@abstract}\markboth{\sjtu@label@abstract}{}}{}
 \newcommand\keywords[1]{\vspace{2ex}\noindent{\bf\large \sjtu@label@keywords} #1}
-\newenvironment{englishabstract}{\chapter*{\sjtu@value@englishtitle\vskip 20pt\bfseries \sjtu@label@englishabstract}\markboth{\sjtu@label@englishabstract}{}}{}
+\newenvironment{englishabstract}{\cleardoublepage\pdfbookmark[0]{\sjtu@label@englishabstract}{englishabstract}
+\chapter*{\sjtu@value@englishtitle\vskip 20pt\bfseries \sjtu@label@englishabstract}\markboth{\sjtu@label@englishabstract}{}}{}
 \newcommand\englishkeywords[1]{\vspace{2ex}\noindent{\bf\large \sjtu@label@englishkeywords} #1}
 
 \renewcommand\tableofcontents{%
+  \cleardoublepage
+  \pdfbookmark[0]{\contentsname}{toc}
   \chapter*{\contentsname}
   \@mkboth{\MakeUppercase\contentsname}{\MakeUppercase\contentsname}%
   \@starttoc{toc}%

--- a/thesis.tex
+++ b/thesis.tex
@@ -49,8 +49,6 @@
 \include{tex/abstract}
 
 %% 目录、插图目录、表格目录
-\cleardoublepage
-\pdfbookmark{\contentsname}{toc}
 \tableofcontents
 \listoffigures
 \addcontentsline{toc}{chapter}{\listfigurename} %将插图目录加入全文目录


### PR DESCRIPTION
自己检查论文时候发现摘要和目录都没有在bookmark中，查看了一下dev版本里目录已经加入bookmark了。我把前中英文摘要也加入了bookmark，顺便为了美观考虑把控制目录bookmark的代码移到了cls文件中