### PR TITLE
添加 Fandol 开源字体选择

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ SJTUThesis 需要使用 XeTeX 引擎编译。2016年的 [TeXLive](https://www.tu
 
 #### 字体
 
-中英文分别依赖 Adobe 的四套简体中文字体和 TeX Gyre Termes 西文字体。Tex Gyre Termes 可从 [CTAN](http://www.ctan.org/tex-archive/fonts/tex-gyre/fonts/opentype/public/tex-gyre) 下载四种不同字型。出于版权考虑，需要大家自行解决 AdobeSongStd, AdobeKaitiStd, AdobeHeitiStd, AdobeFangsongStd 四款中文字体的授权问题。
+SJTUThesis 需要五种字体，分别是一套英文字体，和宋体、仿宋、黑体、楷体四种中文字体。在不同的操作系统上，有不同的字体选择。
+
+##### 中文字体选择
+
+在中文字体中，Fandol 开放字体和 Adobe 付费字体是全系统支持的（Linux、macOS、Windows 等）。其中 Fandol 是开源在 GPL 许可证下的，不涉及字体版权问题，可在 [https://www.ctan.org/pkg/fandol](https://www.ctan.org/pkg/fandol) 自行下载安装。
+
+Adobe 字体是由 Adobe 推出的中文字体，需要 Adobe 授权使用。因为版权问题，若要使用请大家自行解决 AdobeSongStd, AdobeKaitiStd, AdobeHeitiStd, AdobeFangsongStd 四个中文字体的授权问题。
+
+##### 英文字体选择
+
+SJTUThesis 使用 TeX Gyre Termes 作为英文字体，Tex Gyre Termes 可从 [CTAN](http://www.ctan.org/tex-archive/fonts/tex-gyre/fonts/opentype/public/tex-gyre) 下载四种不同字型。
 
 ### 获取模板
 

--- a/tex/intro.tex
+++ b/tex/intro.tex
@@ -35,8 +35,7 @@
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 	\item {\TeX}系统：所使用的{\TeX}系统要支持 \XeTeX 引擎，且带有ctex 2.x宏包，以2015年的\emph{完整}TeXLive、MacTeX发行版为佳。
-	\item 中英文字体：操作系统中需要安装\footnote{在Windows、Mac OS X 以及 Linux 上安装额外的字体，可以参考\href{https://www.searchfreefonts.com/articles/how-to-install-fonts.htm}{“How to install fonts?”}。
-}TeX Gyre Termes字体\footnote{\url{http://www.gust.org.pl/projects/e-foundry/tex-gyre/termes}}和四款Adobe中文字体
+	\item 中英文字体：操作系统中需要安装\footnote{在Windows、Mac OS X 以及 Linux 上安装额外的字体，可以参考\href{https://www.searchfreefonts.com/articles/how-to-install-fonts.htm}{“How to install fonts?”}。}TeX Gyre Termes字体\footnote{\url{http://www.gust.org.pl/projects/e-foundry/tex-gyre/termes}}和四款Fandol中文开放授权字体\footnote{\url{https://www.ctan.org/pkg/fandol}}，或者四款Adobe中文付费字体
 \footnote{请从合法渠道获得Adobe字体。}：AdobeSongStd、AdobeKaitiStd、AdobeHeitiStd、AdobeFangsongStd。
 	\item TeX技能：尽管提供了对模板的必要说明，但这不是一份“ \LaTeX 入门文档”。在使用前请先通读其他入门文档。
 	\item 针对Windows用户的额外需求：学位论文模本分别使用git和GNUMake进行版本控制和构建，建议从Cygwin\footnote{\url{http://cygwin.com}}安装这两个工具。
@@ -50,7 +49,7 @@ sjtuthesis提供了一些常用选项，在thesis.tex在导入sjtuthesis模板�
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 \item 学位类型：bachelor(学位)、master(硕士)、doctor(博士)，是必选项。
-\item 中国字体：adobefonts(Adobe中文字体)、winfonts(使用Windows下的中文字体，该选项未在Linux/Mac下测试)。
+\item 中国字体：fandolfonts(Fandol开源字体)、adobefonts(Adobe中文付费字体)、winfonts(使用Windows下的中文字体，该选项未在Linux/Mac下测试)。
 \item 正文字号：cs4size(小四)、c5size(五号)。
 \item 盲审选项：使用review选项后，论文作者、学号、导师姓名、致谢、发表论文和参与项目将被隐去。
 \end{itemize}

--- a/thesis.tex
+++ b/thesis.tex
@@ -4,17 +4,17 @@
 %%==================================================
 
 % 双面打印
-\documentclass[doctor, fontset=adobe, openright, twoside]{sjtuthesis}
-% \documentclass[bachelor, fontset=adobe, openany, oneside, submit]{sjtuthesis}
-% \documentclass[master, fontset=adobe, review]{sjtuthesis}
-% \documentclass[%
-%   bachelor|master|doctor,	% 必选项
-%   fontset=adobe|windows,  	% 只测试了adobe
-%   oneside|twoside,		% 单面打印，双面打印(奇偶页交换页边距，默认)
-%   openany|openright, 		% 可以在奇数或者偶数页开新章|只在奇数页开新章(默认)
-%   zihao=-4|5,, 		% 正文字号：小四、五号(默认)
-%   review,	 		% 盲审论文，隐去作者姓名、学号、导师姓名、致谢、发表论文和参与的项目
-%   submit			% 定稿提交的论文，插入签名扫描版的原创性声明、授权声明 
+\documentclass[doctor, fontset=fandol, openright, twoside]{sjtuthesis}
+% \documentclass[bachelor, fontset=fandol, openany, oneside, submit]{sjtuthesis}
+% \documentclass[master, fontset=fandol, review]{sjtuthesis}
+% \documentclass[
+%   bachelor|master|doctor,           % 必选项
+%   fontset=adobe|windows|fandol,     % 字体选择，需要先安装对应字体
+%   oneside|twoside,		              % 单面打印，双面打印(奇偶页交换页边距，默认)
+%   openany|openright, 		            % 可以在奇数或者偶数页开新章|只在奇数页开新章(默认)
+%   zihao=-4|5,, 		                  % 正文字号：小四、五号(默认)
+%   review,	 		                      % 盲审论文，隐去作者姓名、学号、导师姓名、致谢、发表论文和参与的项目
+%   submit			                      % 定稿提交的论文，插入签名扫描版的原创性声明、授权声明 
 % ]
 
 % 逐个导入参考文献数据库


### PR DESCRIPTION
Fandol 是 LaTeX 可用的著名开源中文字体解决方案，可用来替换 Adobe 中文字体，解决版权问题。

## What have I do

更新了文档（readme 和 thesis 本身）

## Related Issues

* https://github.com/dyweb/mos/issues/14
* https://github.com/weijianwen/SJTUThesis/issues/80

Signed-off-by: Ce Gao <ce.gao@outlook.com>