### PR TITLE
添加英文模版支持

### DIFF
--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -5,17 +5,7 @@
 
 \ProvidesFile{sjtuthesis.cfg}[2016/04/06 v0.9 sjtuthesis configuration file]
 
-%% 目录、插图索引、表格索引
-\def\sjtu@contentsname{目~~~~录}
-\def\sjtu@figurename{图}
-\def\sjtu@listfigurename{插图索引}
-\def\sjtu@tablename{表}
-\def\sjtu@listtablename{表格索引}
-\def\sjtu@listalgorithmname{算法索引}
-
-%%
 %% labels in the title page
-%%
 \def\sjtu@label@major{专业}
 \def\sjtu@label@title{论文题目}
 \def\sjtu@label@thesis{学位论文}
@@ -32,10 +22,7 @@
   \def\sjtu@label@advisor{导师}
 \fi
 
-%%
 %% string values filled in the title page
-%%
-
 \def\sjtu@value@classification{}
 \def\sjtu@value@confidential{}
 \def\sjtu@value@serialnumber{}
@@ -50,7 +37,7 @@
   \else
     \ifsjtu@doctor
       \def\sjtu@value@chinesedegree{博士}
-    \def\sjtu@value@englishdegree{Doctor}
+      \def\sjtu@value@englishdegree{Doctor}
     \else
       \ClassError{sjtuthesis}%
       {Unknown value for degree.}{}
@@ -59,7 +46,7 @@
 \fi
 \def\sjtu@label@statement{申请\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis} 
 
-% 论文原创性声明
+%% 论文原创性声明
 \def\sjtu@label@original{学位论文原创性声明}
 \def\sjtu@label@authorization{学位论文版权使用授权书}
 \def\sjtu@label@authorsign{学位论文作者签名：}
@@ -74,62 +61,92 @@
         （请在以上方框内打$\checked$）
 }
 
-
-%%
 %% labels in the english title page
-%%
 \def\sjtu@label@englishadvisor{Advisor}
 \def\sjtu@label@englishcoadvisor{Co-advisor}
 \def\sjtu@label@englishstatement{Submitted in total fulfillment
   of the requirements for the degree of \sjtu@value@englishdegree \\
   in \sjtu@value@englishmajor}
 
-%%
 %% labels in the abstracts
-%%
-\def\sjtu@label@abstract{摘~~~~要}
-\def\sjtu@label@englishabstract{ABSTRACT}
+\def\sjtu@label@chineseabstract{摘~~~~要}
+\def\sjtu@label@englishabstract{Abstract}
 \def\sjtu@label@keywords{关键词：}
 \def\sjtu@label@englishkeywords{KEY WORDS:~}
 
+\ifsjtu@english
+
+%% labels in the titlepage, contents, lists, etc.
+\def\sjtu@titlepage{Title Page}
+\def\sjtu@label@abstract{\sjtu@label@englishabstract}
+\def\sjtu@contentsname{Contents}
+\def\sjtu@figurename{Figure}
+\def\sjtu@listfigurename{List of Figures}
+\def\sjtu@tablename{Table}
+\def\sjtu@listtablename{List of Tables}
+\def\sjtu@algorithmicrequire{Input:}
+\def\sjtu@algorithmicensure{Output:}
+\def\sjtu@listalgorithmname{List of Algorithms}
+\def\sjtu@nomenclature{Nomenclature}
+\DefineBibliographyStrings{english}{%
+  bibliography = {Bibliography}
+}
+%% labels in the summary
+\def\sjtu@label@summary{Summary}
+%% labels in the publications
+\def\sjtu@label@publications{Publications}
+%% labels in the publications
+\def\sjtu@label@patents{Patents}
+%% labels in the projects
+\def\sjtu@label@projects{Projects}
+%% labels in the resume
+\def\sjtu@label@resume{Resume}
+%% labels in the thanks
+\def\sjtu@label@thanks{Acknowledgements}
+%% listings name
+\def\sjtu@value@listingname{Code}
+%% the theorem name definitions
+\def\sjtu@label@algo{Algorithm}
+\def\sjtu@label@thm{Theorem}
+\def\sjtu@label@lem{Lemma}
+\def\sjtu@label@prop{Proposition}
+\def\sjtu@label@cor{Corollary}
+\def\sjtu@label@defn{Definition}
+\def\sjtu@label@conj{Conjecture}
+\def\sjtu@label@exmp{Example}
+\def\sjtu@label@rem{Remark}
+\def\sjtu@label@case{Case}
+\def\sjtu@label@proof{Proof}
+
+\else
+
+%% 目录、插图索引、表格索引
+\def\sjtu@titlepage{扉~~~~页}
+\def\sjtu@label@abstract{\sjtu@label@chineseabstract}
+\def\sjtu@contentsname{目~~~~录}
+\def\sjtu@figurename{图}
+\def\sjtu@listfigurename{插图索引}
+\def\sjtu@tablename{表}
+\def\sjtu@listtablename{表格索引}
+\def\sjtu@algorithmicrequire{输入:}
+\def\sjtu@algorithmicensure{输出:}
+\def\sjtu@listalgorithmname{算法索引}
+\def\sjtu@nomenclature{主要符号对照表}
 %% labels in the summary
 \def\sjtu@label@summary{全文总结}
-
-%%
 %% labels in the publications
-%%
 \def\sjtu@label@publications{攻读学位期间发表的学术论文}
-
-%%
 %% labels in the publications
-%%
 \def\sjtu@label@patents{攻读学位期间申请的专利}
-
-%%
 %% labels in the projects
-%%
 \def\sjtu@label@projects{攻读学位期间参与的项目}
-
-
-%%
 %% labels in the resume
-%%
 \def\sjtu@label@resume{简~~~~历}
-
-
-%%
 %% labels in the thanks
-%%
 \def\sjtu@label@thanks{致~~~~谢}
-
-%%%
 %% listings name
-%%
 \def\sjtu@value@listingname{代码}
-
-%%
 %% the theorem name definitions
-%%
 \def\sjtu@label@algo{算法}
 \def\sjtu@label@thm{定理}
 \def\sjtu@label@lem{引理}
@@ -141,6 +158,8 @@
 \def\sjtu@label@rem{注}
 \def\sjtu@label@case{情形}
 \def\sjtu@label@proof{证明}
+
+\fi
 
 \endinput
 

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -9,18 +9,26 @@
 \newif\ifsjtu@bachelor\sjtu@bachelorfalse
 \newif\ifsjtu@master\sjtu@masterfalse
 \newif\ifsjtu@doctor\sjtu@doctorfalse
+\newif\ifsjtu@english\sjtu@englishfalse
 \newif\ifsjtu@review\sjtu@reviewfalse
 \newif\ifsjtu@submit\sjtu@submitfalse
 \DeclareOption{bachelor}{\sjtu@bachelortrue}
 \DeclareOption{master}{\sjtu@mastertrue}
 \DeclareOption{doctor}{\sjtu@doctortrue}
+\DeclareOption{english}{\sjtu@englishtrue}
 \DeclareOption{review}{\sjtu@reviewtrue}
 \DeclareOption{submit}{\sjtu@submittrue}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
-\PassOptionsToPackage{no-math}{fontspec}
-\LoadClass[a4paper,UTF8,scheme=chinese]{ctexbook}
-\ifsjtu@bachelor\relax\else
+\ifsjtu@english
+  \PassOptionsToClass{scheme=plain}{ctexbook}
+\else
+  \PassOptionsToClass{scheme=chinese}{ctexbook}
+\fi
+\ifsjtu@bachelor
+  \PassOptionsToClass{zihao=5}{ctexbook}
+\else
+  \PassOptionsToClass{zihao=-4}{ctexbook}
   \ifsjtu@master\relax\else
     \ifsjtu@doctor\relax\else
       \ClassError{sjtuthesis}%
@@ -28,6 +36,8 @@
     \fi
   \fi
 \fi
+\PassOptionsToPackage{no-math}{fontspec}
+\LoadClass[a4paper,UTF8]{ctexbook}
 
 %% sjtuthesis.cls segments
 % 0. Import sjtuthesis.cfg
@@ -42,7 +52,6 @@
 
 %% 导入 sjtuthesis.cfg 文件
 \AtEndOfClass{\input{sjtuthesis.cfg}}
-
 
 %==========
 % Segment 1. Import LaTeX packages.
@@ -139,15 +148,17 @@
 \ctexset{listfigurename={\sjtu@listfigurename}}
 \ctexset{listtablename={\sjtu@listtablename}}
 \floatname{algorithm}{\sjtu@label@algo}
-\renewcommand{\algorithmicrequire}{\textbf{输入:}} 
-\renewcommand{\algorithmicensure}{\textbf{输出:}}
+\renewcommand{\algorithmicrequire}{\textbf{\sjtu@algorithmicrequire}} 
+\renewcommand{\algorithmicensure}{\textbf{\sjtu@algorithmicensure}}
 \renewcommand{\listalgorithmname}{\sjtu@listalgorithmname}
 \renewcommand{\lstlistingname}{\sjtu@value@listingname}
 
 % Title Settings at the chapter Level
 \ctexset{chapter={
+	format={\centering},
 	nameformat={\Large\bfseries},
 	titleformat={\Large\bfseries},
+	aftername={\quad},
 	beforeskip={15\p@},
 	afterskip={12\p@},
 	}
@@ -172,6 +183,9 @@
 	afterskip={1.0ex \@plus .2ex},
 	}
 }
+
+% Set indent in English mode
+\ifsjtu@english\setlength{\parindent}{2\ccwd}\fi
 
 % bullets in the item
 \renewcommand{\labelitemi}{\ensuremath{\bullet}}
@@ -287,7 +301,7 @@
   \newtheorem{blem}[thm]{\sjtu@label@lem~}
   \newtheorem{bprop}[thm]{\sjtu@label@prop~}
   \newtheorem{bcor}[thm]{\sjtu@label@cor~}
-  \renewcommand{\proofname}{\bf\sjtu@label@proof}
+  \renewcommand{\proofname}{\bfseries\sjtu@label@proof}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % The following definitions add Switch statement to LaTeX algorithmicx package
@@ -322,7 +336,7 @@
 %==========
 
 \renewcommand\maketitle{%
-  \pdfbookmark[0]{扉~~~~页}{titlepage}
+  \pdfbookmark[0]{\sjtu@titlepage}{titlepage}
   \ifsjtu@bachelor
     \makechinesetitle@bachelor
   \else
@@ -336,9 +350,7 @@
 \newcommand\confidential[1]{\def\sjtu@value@confidential{#1}}
 \newcommand\school[1]{\def\sjtu@value@school{#1}}
 \newcommand\chinesedegree[1]{\def\sjtu@value@chinesedegree{#1}}
-\renewcommand\title[2][\sjtu@value@title]{%
-  \def\sjtu@value@title{#2}
-  \def\sjtu@value@titlemark{\MakeUppercase{#1}}}
+\renewcommand\title[1]{\def\sjtu@value@chinesetitle{#1}}
 \renewcommand\author[1]{\def\sjtu@value@author{#1}}
 \newcommand\advisor[1]{\def\sjtu@value@advisor{#1}}
 \newcommand\coadvisor[1]{\def\sjtu@value@coadvisor{#1}}
@@ -355,12 +367,12 @@
   \begin{center}
   {\songti\zihao{-3}\sjtu@label@statement}
   \vskip\stretch{1}
-  {\heiti\zihao{3}\sjtu@value@title}
+  {\heiti\zihao{3}\sjtu@value@chinesetitle}
   \vskip\stretch{1}
   {\fangsong\zihao{4}}
   \def\tabcolsep{1pt}
   \def\arraystretch{1.5}
-  \begin{tabular}{>{\begin{CJKfilltwosides}{4em}\heiti}r<{\end{CJKfilltwosides}}l}
+  \begin{tabular}{>{\begin{CJKfilltwosides}{4\ccwd}\heiti}r<{\end{CJKfilltwosides}}l}
     \ifsjtu@review
       \sjtu@label@author        & \underline{\makebox[150pt]{}} \\
       \sjtu@label@studentnumber & \underline{\makebox[150pt]{}} \\
@@ -445,12 +457,12 @@
     {\kaishu\zihao{2}
     \begin{tabular}{r@{：}l}
       \sjtu@label@title &
-      {\zihao{-2}\underline{\begin{minipage}{360pt}\centering\sjtu@value@title\end{minipage}}}
+      {\zihao{-2}\underline{\begin{minipage}{360pt}\centering\sjtu@value@chinesetitle\end{minipage}}}
     \end{tabular}}
     \vskip \stretch{1}
     {\kaishu\zihao{3}
     \def\arraystretch{1.1}
-    \begin{tabular}{>{\begin{CJKfilltwosides}{4em}}r<{\end{CJKfilltwosides}}@{：}l}
+    \begin{tabular}{>{\begin{CJKfilltwosides}{4\ccwd}}r<{\end{CJKfilltwosides}}@{：}l}
       \ifsjtu@review
         \sjtu@label@author        & \underline{\makebox[180pt]{}} \\
         \sjtu@label@studentnumber & \underline{\makebox[180pt]{}} \\
@@ -475,8 +487,8 @@
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-  	{\bf\zihao{3} \sjtu@value@school}\\
-  	{\bf\zihao{3} \sjtu@label@original}
+  	{\bfseries\zihao{3} \sjtu@value@school}\\
+  	{\bfseries\zihao{3} \sjtu@label@original}
   \end{center}
   \vskip 10pt
   {\par\zihao{-4}\sjtu@label@originalcontent\par}
@@ -487,14 +499,13 @@
   \cleardoublepage
 }
 
-
 % 授权声明
 \newcommand\makeDeclareAuthorization{%
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-  	{\bf\zihao{3} \sjtu@value@school}\\
-  	{\bf\zihao{3} \sjtu@label@authorization}
+  	{\bfseries\zihao{3} \sjtu@value@school}\\
+  	{\bfseries\zihao{3} \sjtu@label@authorization}
   \end{center}
   \vskip 10pt
   {\par\zihao{-4}\sjtu@label@authorizationcontent\par}
@@ -506,30 +517,40 @@
 }
 
 % fancyhdr页眉页脚设置
+\ifsjtu@english
+  \def\sjtu@value@titlemark{\sjtu@value@englishtitle}
+  \newcommand\sjtu@fancyhead{\footnotesize\kaishu}
+  \newcommand\sjtu@fancyfoot[1]{\small --~~{\bfseries\thepage}~~of~~{\bfseries{#1}}~~--}
+\else
+  \def\sjtu@value@titlemark{\sjtu@value@chinesetitle}
+  \newcommand\sjtu@fancyhead{\small\kaishu}
+  \newcommand\sjtu@fancyfoot[1]{\small 第~{\bfseries\thepage}~页\,共~{\bfseries{#1}}~页}
+\fi
+\def\markboxwidth{0.75\textwidth}
 \ifsjtu@bachelor
 	% 本科学位论文页眉页脚设置
 	%% 正文页眉页脚
 	\fancypagestyle{main}{
 	  \fancyhf{}
-	  \fancyhead[L]{\includegraphics[width=0.22\textwidth]{figure/sjtubanner}}
-	  \fancyhead[R]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-	  \fancyfoot[C]{\small 第~{\bfseries\thepage}~页\,共~{\bfseries\pageref{last}}~页}
+	  \fancyhead[L]{\includegraphics{figure/sjtubanner}}
+	  \fancyhead[R]{\parbox[b]{\markboxwidth}{\raggedleft\nouppercase{\sjtu@fancyhead\sjtu@value@titlemark}}}
+	  \fancyfoot[C]{\sjtu@fancyfoot{\pageref{last}}}
 	  \renewcommand{\headheight}{32pt}
 	}
   %% 英文大摘要
   \fancypagestyle{biglast}{
     \fancyhf{}
-    \fancyhead[L]{\includegraphics[width=0.22\textwidth]{figure/sjtubanner}}
-    \fancyhead[R]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-    \fancyfoot[C]{\small 第~{\bfseries\thepage}~页\,共~{\bfseries\pageref{biglast}}~页}
+    \fancyhead[L]{\includegraphics{figure/sjtubanner}}
+    \fancyhead[R]{\parbox[b]{\markboxwidth}{\raggedleft\nouppercase{\sjtu@fancyhead\sjtu@value@titlemark}}}
+    \fancyfoot[C]{\sjtu@fancyfoot{\pageref{biglast}}}
     \renewcommand{\headheight}{32pt}
   }
 	%% 开章页页眉页脚
 	\fancypagestyle{plain}{% 设置开章页页眉页脚风格(只有页码作为页脚)
 	  \fancyhf{}
-	  \fancyhead[L]{\nouppercase{\small\kaishu\includegraphics[width=0.22\textwidth]{figure/sjtubanner}}}
-	  \fancyhead[R]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-	  \fancyfoot[C]{\small 第~{\bf\thepage}~页\,共~{\bf\pageref{last}}~页}
+	  \fancyhead[L]{\includegraphics{figure/sjtubanner}}
+	  \fancyhead[R]{\parbox[b]{\markboxwidth}{\raggedleft\nouppercase{\sjtu@fancyhead\sjtu@value@titlemark}}}
+	  \fancyfoot[C]{\sjtu@fancyfoot{\pageref{last}}}
 	  \renewcommand{\headheight}{32pt}
 	}
 \else
@@ -537,47 +558,50 @@
 	\if@twoside
 	  %% 正文页眉页脚
 	  \fancypagestyle{main}{
-	    \fancyhead[LO, RE]{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
-	    \fancyhead[RO]{\nouppercase{\small\kaishu\leftmark}}
-	    \fancyhead[LE]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
+	    \fancyhf{}
+	    \fancyhead[LO,RE]{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+	    \fancyhead[LE,RO]{\nouppercase{\sjtu@fancyhead\leftmark}}
 	    \fancyfoot[C]{\small ---~{\bfseries\thepage}~---}
 	    \renewcommand{\headheight}{32pt}
 	  }
 	  %% 开章页页眉页脚
 	  \fancypagestyle{plain}{
 	    \fancyhf{}
-	    \fancyhead[LO,RE]{\nouppercase{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}}
-	    \fancyhead[RO]{\nouppercase{\small\kaishu\leftmark}}
-	    \fancyhead[LE]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-	    \fancyfoot[C]{\small ---~{\bf\thepage}~---}
+	    \fancyhead[LO,RE]{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+	    \fancyhead[LE,RO]{\nouppercase{\sjtu@fancyhead\leftmark}}
+	    \fancyfoot[C]{\small ---~{\bfseries\thepage}~---}
 	    \renewcommand{\headheight}{32pt}
 	  }
 	\else
 	%% 正文页
 	\fancypagestyle{main}{
+	  \fancyhf{}
 	  \fancyhead[L]{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
-	  \fancyhead[R]{\nouppercase{\small\kaishu\leftmark}}
-	  \fancyfoot[C]{\small ---~{\bf\thepage}~---}
+	  \fancyhead[R]{\nouppercase{\sjtu@fancyhead\leftmark}}
+	  \fancyfoot[C]{\small ---~{\bfseries\thepage}~---}
 	  \renewcommand{\headheight}{32pt}
 	}
 	\fancypagestyle{plain}{
 	  \fancyhf{}
-	  \fancyhead[L]{\nouppercase{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}}
-	  \fancyhead[R]{\nouppercase{\small\kaishu\leftmark}}
-	  % \fancyhead[L]{\small {\it\sjtu@value@titlemark}}
-	  \fancyfoot[C]{\small ---~{\bf\thepage}~---}
+	  \fancyhead[L]{\small\kaishu\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+	  \fancyhead[R]{\nouppercase{\sjtu@fancyhead\leftmark}}
+	  \fancyfoot[C]{\small ---~{\bfseries\thepage}~---}
 	  \renewcommand{\headheight}{32pt}
 	}
 	\fi
 \fi
 
 % 中英文摘要
-\newenvironment{abstract}{\cleardoublepage \pdfbookmark[0]{\sjtu@label@abstract}{abstract}
-\chapter*{\sjtu@value@title\vskip 20pt\sjtu@label@abstract}\markboth{\sjtu@label@abstract}{}}{}
-\newcommand\keywords[1]{\vspace{2ex}\noindent{\bf\large \sjtu@label@keywords} #1}
-\newenvironment{englishabstract}{\cleardoublepage\pdfbookmark[0]{\sjtu@label@englishabstract}{englishabstract}
-\chapter*{\sjtu@value@englishtitle\vskip 20pt\bfseries \sjtu@label@englishabstract}\markboth{\sjtu@label@englishabstract}{}}{}
-\newcommand\englishkeywords[1]{\vspace{2ex}\noindent{\bf\large \sjtu@label@englishkeywords} #1}
+\newenvironment{abstract}{\cleardoublepage \pdfbookmark[0]{\sjtu@label@abstract}{abstract} \ifsjtu@english\let\@afterindentfalse\relax\fi
+\chapter*{\sjtu@value@chinesetitle\vskip 20pt\sjtu@label@chineseabstract}\markboth{\sjtu@label@chineseabstract}{}}{}
+\newcommand\keywords[1]{\vspace{2ex}\noindent{\bfseries\large \sjtu@label@keywords} #1}
+\newenvironment{englishabstract}{\cleardoublepage
+\chapter*{\MakeUppercase\sjtu@value@englishtitle\vskip 20pt\bfseries \MakeUppercase\sjtu@label@englishabstract}\markboth{\sjtu@label@englishabstract}{}}{}
+\newcommand\englishkeywords[1]{\vspace{2ex}\noindent{\bfseries\large \sjtu@label@englishkeywords} #1}
+
+% 主要符号对照表
+\newenvironment{nomenclaturename}{\cleardoublepage
+\chapter{\sjtu@nomenclature}{}}{}
 
 \renewcommand\tableofcontents{%
   \cleardoublepage
@@ -688,21 +712,21 @@
 \setcounter{page}{1}
 \fancypagestyle{biglast}{
   \fancyhf{}
-  \fancyhead[L]{\includegraphics[width=0.22\textwidth]{figure/sjtubanner}}
-  \fancyhead[R]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-  \fancyfoot[C]{\small 第~{\bfseries\thepage}~页\,共~{\bfseries\pageref{biglast}}~页}
+  \fancyhead[L]{\includegraphics{figure/sjtubanner}}
+  \fancyhead[R]{\parbox[b]{\markboxwidth}{\raggedleft\nouppercase{\sjtu@fancyhead\sjtu@value@titlemark}}}
+  \fancyfoot[C]{\sjtu@fancyfoot{\pageref{biglast}}}
   \renewcommand{\headheight}{32pt}
 }
 
 \fancypagestyle{plain}{% 设置开章页页眉页脚风格(只有页码作为页脚)
   \fancyhf{}
-  \fancyhead[L]{\includegraphics[width=0.22\textwidth]{figure/sjtubanner}}
-  \fancyhead[R]{\nouppercase{\small\kaishu\sjtu@value@titlemark}}
-  \fancyfoot[C]{\small 第~{\bf\thepage}~页\,共~{\bf\pageref{biglast}}~页}
+  \fancyhead[L]{\includegraphics{figure/sjtubanner}}
+  \fancyhead[R]{\parbox[b]{\markboxwidth}{\raggedleft\nouppercase{\sjtu@fancyhead\sjtu@value@titlemark}}}
+  \fancyfoot[C]{\sjtu@fancyfoot{\pageref{biglast}}}
   \renewcommand{\headheight}{32pt}
 }
 
-\chapter*{\bf\MakeUppercase{\sjtu@value@englishtitle}\vskip 20pt }
+\chapter*{\bfseries\MakeUppercase{\sjtu@value@englishtitle}\vskip 20pt }
 }
 {\label{biglast}}
 
@@ -710,4 +734,3 @@
 
 %%
 %% End of file `sjtuthesis.cls'.
-

--- a/tex/intro.tex
+++ b/tex/intro.tex
@@ -46,10 +46,10 @@ sjtuthesis提供了一些常用选项，在thesis.tex在导入sjtuthesis模板�
 这些选项包括：
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
-\item 学位类型：bachelor(学位)、master(硕士)、doctor(博士)，是必选项。
-\item 中文字体：fandol(Fandol 开源字体)、windows(Windows 系统下的中文字体)、mac(macOS 系统下的华文字体)、ubuntu(Ubuntu 系统下的文泉驿和文鼎字体)、adobe(Adobe 公司的中文字体)、founder(方正公司的中文字体)，默认根据操作系统自动配置。
-\item 正文字号：cs4size(小四)、c5size(五号)。
-\item 盲审选项：使用review选项后，论文作者、学号、导师姓名、致谢、发表论文和参与项目将被隐去。
+	\item 学位类型：bachelor(学位)、master(硕士)、doctor(博士)，是必选项。
+	\item 中文字体：fandol(Fandol 开源字体)、windows(Windows 系统下的中文字体)、mac(macOS 系统下的华文字体)、ubuntu(Ubuntu 系统下的文泉驿和文鼎字体)、adobe(Adobe 公司的中文字体)、founder(方正公司的中文字体)，默认根据操作系统自动配置。
+	\item 英文模版：使用english选项启用英文模版。
+	\item 盲审选项：使用review选项后，论文作者、学号、导师姓名、致谢、发表论文和参与项目将被隐去。
 \end{itemize}
 
 \subsection{编译模板}

--- a/tex/symbol.tex
+++ b/tex/symbol.tex
@@ -1,5 +1,5 @@
 %# -*- coding: utf-8-unix -*-
-\chapter{主要符号对照表}
+\begin{nomenclaturename}
 \label{chap:symb}
 
 \begin{longtable}{rl}
@@ -58,3 +58,5 @@ $\epsilon$     & 介电常数 \\
  $\epsilon$     & 介电常数 \\
  $\mu$ 		& 磁导率 \\
 \end{longtable}
+
+\end{nomenclaturename}

--- a/thesis.tex
+++ b/thesis.tex
@@ -12,7 +12,7 @@
 %   fontset=fandol|windows|mac|ubuntu|adobe|founder, % 字体选项
 %   oneside|twoside,		% 单面打印，双面打印(奇偶页交换页边距，默认)
 %   openany|openright, 		% 可以在奇数或者偶数页开新章|只在奇数页开新章(默认)
-%   zihao=-4|5,, 		% 正文字号：小四、五号(默认)
+%   english,			% 启用英文模版
 %   review,	 		% 盲审论文，隐去作者姓名、学号、导师姓名、致谢、发表论文和参与的项目
 %   submit			% 定稿提交的论文，插入签名扫描版的原创性声明、授权声明 
 % ]


### PR DESCRIPTION
**Description:**
- [x] 添加英文模版支持；
- [x] 页眉设置；
- [x] 移除字号大小选项。

**Related Issues:**
#205 

添加英文模版支持，新增模版选项 `english`，除了页眉设置基本都完成了。页眉的问题主要是因为英文标题往往太长了，放在页眉不好实现美观的效果。这一点希望和大家讨论一下。`ctex` 宏包在 `scheme=plain` 选项下不会调整默认字号，需要显式指定默认字号大小。为方便使用，默认本科生论文模版使用五号字，研究生模版使用小四号字。

<img width="245" alt="screen shot 2017-12-06 at 21 22 01" src="https://user-images.githubusercontent.com/15205102/33663671-db1fd216-dacb-11e7-8f71-5cf8b3ae0552.png">
