### PR TITLE
新的字体设置

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,11 @@ SJTUThesis 需要使用 XeTeX 引擎编译。Linux 用户可以安装 [TeX Live]
 
 注：**Windows用户**推荐使用 [Babun](http://babun.github.io/) 作为命令行终端。Babun 已默认安装有这些工具：git(用于版本控制)、GNUmake(用于编译控制)、perl(用于字数统计)。
 
-#### 字体
+#### 中文字体
 
-SJTUThesis 使用 [CTeX](https://www.ctan.org/pkg/ctex?lang=en) 提供中文支持，共需要五种字体，分别是一套英文字体，和宋体、仿宋、黑体、楷体四种中文字体。在不同的操作系统上，有不同的字体选择。
+SJTUThesis 由 [CTeX](https://www.ctan.org/pkg/ctex?lang=en) 宏集提供中文支持，CTeX 宏集预定义了六种不同的中文字体配置，以适应不同的操作系统。
 
-##### 中文字体选择
-
-在中文字体中，Fandol 开放字体和 Adobe 付费字体是全系统支持的（Linux、macOS、Windows 等）。其中 Fandol 是开源在 GPL 许可证下的，不涉及字体版权问题，可在 [https://www.ctan.org/pkg/fandol](https://www.ctan.org/pkg/fandol) 自行下载安装。
-
-Adobe 字体是由 Adobe 推出的中文字体，需要 Adobe 授权使用。因为版权问题，若要使用请大家自行解决 AdobeSongStd, AdobeKaitiStd, AdobeHeitiStd, AdobeFangsongStd 四个中文字体的授权问题。
-
-##### 英文字体选择
-
-SJTUThesis 使用 TeX Gyre Termes 作为英文字体，Tex Gyre Termes 可从 [CTAN](http://www.ctan.org/tex-archive/fonts/tex-gyre/fonts/opentype/public/tex-gyre) 下载四种不同字型。
+模版默认选用 Fandol 中文字库。 Fandol 字库是一套采用 GPL 许可证的开源字体，不涉及版权问题，而且支持绝大多数的操作系统（Linux、macOS、Windows 等）。可在 [https://www.ctan.org/pkg/fandol](https://www.ctan.org/pkg/fandol) 自行下载安装。你也可以根据自己的实际需要选择其他字体配置。
 
 ### 获取模板
 

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -18,6 +18,7 @@
 \DeclareOption{submit}{\sjtu@submittrue}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
+\PassOptionsToPackage{no-math}{fontspec}
 \LoadClass[a4paper,UTF8,scheme=chinese]{ctexbook}
 \ifsjtu@bachelor\relax\else
   \ifsjtu@master\relax\else
@@ -50,14 +51,18 @@
 \RequirePackage[centering,a4paper,body={16cm,22cm}]{geometry} %设置版面
 \RequirePackage{fancyhdr}
 \RequirePackage{lastpage}
-\RequirePackage{fontspec}
+\RequirePackage{mathtools,amsthm,amsfonts,amssymb,bm}
+\RequirePackage[defaultsups]{newtxtext}
+\RequirePackage{newtxmath}
+\RequirePackage{sourcecodepro}
+\RequirePackage{upgreek}
+\RequirePackage{wasysym}
+\RequirePackage{anyfontsize}
 \RequirePackage{metalogo,doc}
 \RequirePackage{threeparttable}
 \RequirePackage{dcolumn}
 \RequirePackage{multirow}
 \RequirePackage{booktabs}
-\RequirePackage{mathtools,amsthm,amsfonts,amssymb,bm,mathrsfs} 
-\RequirePackage{upgreek}
 \RequirePackage{graphicx}
 \RequirePackage{subfigure}
 \RequirePackage{caption}
@@ -72,7 +77,6 @@
   {\usebibmacro{cite:dump}%
    \usebibmacro{postnote}]}
 \RequirePackage{xcolor}
-\RequirePackage{wasysym}
 \RequirePackage{listings}
 \RequirePackage[xetex, bookmarksnumbered, colorlinks, urlcolor=black, linkcolor=black, citecolor=black, plainpages=false, pdfstartview=FitH]{hyperref}
 \RequirePackage{longtable}
@@ -124,9 +128,6 @@
 %==========
 % Segment 3. Configure the imported packages, also extend LaTeX command in sjtuthesis
 %==========
-
-% Set the mainfont
-\setmainfont{TeX Gyre Termes}
 
 %% 行距缩放因子
 \linespread{1.3}
@@ -254,6 +255,9 @@
   extendedchars=false,columns=flexible,mathescape=true
   numbersep=-1em
 }
+
+% Setting Package siunitx
+\sisetup{detect-all} % Detecting fonts
 
 % 定理环境
 \newtheoremstyle{break}% name

--- a/tex/intro.tex
+++ b/tex/intro.tex
@@ -31,12 +31,11 @@
 \subsection{准备工作}
 \label{sec:requirements}
 
-要使用这个模板撰写学位论文，需要在\emph{TeX系统}、\emph{中英文字体}、\emph{TeX技能}上有所准备。
+要使用这个模板撰写学位论文，需要在\emph{TeX系统}、\emph{中文字体}、\emph{TeX技能}上有所准备。
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 	\item {\TeX}系统：所使用的{\TeX}系统要支持 \XeTeX 引擎，且带有ctex 2.x宏包，以2015年的\emph{完整}TeXLive、MacTeX发行版为佳。
-	\item 中英文字体：操作系统中需要安装\footnote{在Windows、Mac OS X 以及 Linux 上安装额外的字体，可以参考\href{https://www.searchfreefonts.com/articles/how-to-install-fonts.htm}{“How to install fonts?”}。}TeX Gyre Termes字体\footnote{\url{http://www.gust.org.pl/projects/e-foundry/tex-gyre/termes}}和四款Fandol中文开放授权字体\footnote{\url{https://www.ctan.org/pkg/fandol}}，或者四款Adobe中文付费字体
-\footnote{请从合法渠道获得Adobe字体。}：AdobeSongStd、AdobeKaitiStd、AdobeHeitiStd、AdobeFangsongStd。
+	\item 中文字体：模板使用 \CTeX 宏集预定义的字体配置，默认使用开源的 Fandol 字库\footnote{\url{https://www.ctan.org/pkg/fandol}}。也可以使用 \CTeX 宏集预定义的其他中文字库，使用前需确保操作系统中安装了相应的字体\footnote{在Windows、macOS 以及 Linux 上安装额外的字体，可以参考\href{https://www.searchfreefonts.com/articles/how-to-install-fonts.htm}{“How to install fonts?”}。}。
 	\item TeX技能：尽管提供了对模板的必要说明，但这不是一份“ \LaTeX 入门文档”。在使用前请先通读其他入门文档。
 	\item 针对Windows用户的额外需求：学位论文模本分别使用git和GNUMake进行版本控制和构建，建议从Cygwin\footnote{\url{http://cygwin.com}}安装这两个工具。
 \end{itemize}
@@ -49,7 +48,7 @@ sjtuthesis提供了一些常用选项，在thesis.tex在导入sjtuthesis模板�
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 \item 学位类型：bachelor(学位)、master(硕士)、doctor(博士)，是必选项。
-\item 中国字体：fandolfonts(Fandol开源字体)、adobefonts(Adobe中文付费字体)、winfonts(使用Windows下的中文字体，该选项未在Linux/Mac下测试)。
+\item 中文字体：fandol(Fandol 开源字体)、windows(Windows 系统下的中文字体)、mac(macOS 系统下的华文字体)、ubuntu(Ubuntu 系统下的文泉驿和文鼎字体)、adobe(Adobe 公司的中文字体)、founder(方正公司的中文字体)。
 \item 正文字号：cs4size(小四)、c5size(五号)。
 \item 盲审选项：使用review选项后，论文作者、学号、导师姓名、致谢、发表论文和参与项目将被隐去。
 \end{itemize}

--- a/thesis.tex
+++ b/thesis.tex
@@ -9,7 +9,7 @@
 % \documentclass[master, fontset=fandol, review]{sjtuthesis}
 % \documentclass[%
 %   bachelor|master|doctor,	% 必选项
-%   fontset=adobe|windows|fandol, % 字体选项
+%   fontset=fandol|windows|mac|ubuntu|adobe|founder, % 字体选项
 %   oneside|twoside,		% 单面打印，双面打印(奇偶页交换页边距，默认)
 %   openany|openright, 		% 可以在奇数或者偶数页开新章|只在奇数页开新章(默认)
 %   zihao=-4|5,, 		% 正文字号：小四、五号(默认)


### PR DESCRIPTION
**Description:**

1. 使用宏包引入内置的西文字体，免去了安装西文字体的麻烦，也更方便适配 Sharelatex、Travis CI 等在线服务。使用 `newtx` 宏包，设置主字体为 TeX Gyre Termes，无衬线字体为 TeX Gyre Heros，同时设置了数学字体与主字体风格统一。等宽字体则另外选用了 Adobe 公司开源的 Source Code Pro 字体，与其他字体相比， Source Code Pro 不仅美观，而且字符更全，可以正确显示如图所示的制表符号；<img width="720" alt="screen shot 2017-12-18 at 21 39 27" src="https://user-images.githubusercontent.com/15205102/34108726-2346d7d2-e43c-11e7-9601-fefc4659a2b5.png">

1. 更新了相关文档。