### PR TITLE
更新complie.bat，使之对TexLive有更良好的支持

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,4 +1,5 @@
-@echo off
+chcp 65001
+set Path=%Path%;C:\TexLive\2017\bin\win32;
 del thesis.pdf >nul 2>nul
 if exist thesis.pdf (
 	echo Close the file: thesis.pdf!!!
@@ -8,14 +9,7 @@ if exist thesis.pdf (
 )
 
 echo Compile...
-echo xelatex -no-pdf thesis...
-xelatex -no-pdf thesis 1> nul
-echo biber --debug thesis...
-biber --debug thesis 1> nul
-echo xelatex thesis...
-xelatex thesis 1> nul
-xelatex thesis 1> nul
-echo clean files...
+latexmk -xelatex -gg  thesis.tex & latexmk -c
 del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.loa *.alg *.glsdefs >nul 2>nul
 cd tex
 del *.aux *.run.xml *.bcf *.log *.xdv *.bbl *.bak *.blg *.out *.thm *.toc *.synctex* *.glg *.glo *.gls *.ist *.idx *.ilg *.ind *.acn *.acr *.lof *.lot *.loa *.alg *.glsdefs >nul 2>nul


### PR DESCRIPTION
经过测试windows平台下miktex没法正常编译此模板，所以修改compile.bat，使其对TexLive的windows版本有更良好的支持。