### PR TITLE
[Feature] 使用 CTeX 自动配置字体策略取代手动指定字体

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ SJTUThesis 需要使用 XeTeX 引擎编译。Linux 用户可以安装 [TeX Live]
 
 #### 中文字体
 
-SJTUThesis 由 [CTeX](https://www.ctan.org/pkg/ctex?lang=en) 宏集提供中文支持，CTeX 宏集预定义了六种不同的中文字体配置，以适应不同的操作系统。
-
-模版默认选用 Fandol 中文字库。 Fandol 字库是一套采用 GPL 许可证的开源字体，不涉及版权问题，而且支持绝大多数的操作系统（Linux、macOS、Windows 等）。可在 [https://www.ctan.org/pkg/fandol](https://www.ctan.org/pkg/fandol) 自行下载安装。你也可以根据自己的实际需要选择其他字体配置。
+SJTUThesis 由 [CTeX](https://www.ctan.org/pkg/ctex?lang=en) 宏集提供中文支持，默认情况下可以自动检测操作系统选择字体配置，同时 CTeX 宏集也提供了相应选项以供在自动配置失效或用户有特殊需求的情况下使用。
 
 ### 获取模板
 

--- a/tex/intro.tex
+++ b/tex/intro.tex
@@ -31,11 +31,10 @@
 \subsection{准备工作}
 \label{sec:requirements}
 
-要使用这个模板撰写学位论文，需要在\emph{TeX系统}、\emph{中文字体}、\emph{TeX技能}上有所准备。
+要使用这个模板撰写学位论文，需要在\emph{TeX系统}、\emph{TeX技能}上有所准备。
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 	\item {\TeX}系统：所使用的{\TeX}系统要支持 \XeTeX 引擎，且带有ctex 2.x宏包，以2015年的\emph{完整}TeXLive、MacTeX发行版为佳。
-	\item 中文字体：模板使用 \CTeX 宏集预定义的字体配置，默认使用开源的 Fandol 字库\footnote{\url{https://www.ctan.org/pkg/fandol}}。也可以使用 \CTeX 宏集预定义的其他中文字库，使用前需确保操作系统中安装了相应的字体\footnote{在Windows、macOS 以及 Linux 上安装额外的字体，可以参考\href{https://www.searchfreefonts.com/articles/how-to-install-fonts.htm}{“How to install fonts?”}。}。
 	\item TeX技能：尽管提供了对模板的必要说明，但这不是一份“ \LaTeX 入门文档”。在使用前请先通读其他入门文档。
 	\item 针对Windows用户的额外需求：学位论文模本分别使用git和GNUMake进行版本控制和构建，建议从Cygwin\footnote{\url{http://cygwin.com}}安装这两个工具。
 \end{itemize}
@@ -48,7 +47,7 @@ sjtuthesis提供了一些常用选项，在thesis.tex在导入sjtuthesis模板�
 
 \begin{itemize}[noitemsep,topsep=0pt,parsep=0pt,partopsep=0pt]
 \item 学位类型：bachelor(学位)、master(硕士)、doctor(博士)，是必选项。
-\item 中文字体：fandol(Fandol 开源字体)、windows(Windows 系统下的中文字体)、mac(macOS 系统下的华文字体)、ubuntu(Ubuntu 系统下的文泉驿和文鼎字体)、adobe(Adobe 公司的中文字体)、founder(方正公司的中文字体)。
+\item 中文字体：fandol(Fandol 开源字体)、windows(Windows 系统下的中文字体)、mac(macOS 系统下的华文字体)、ubuntu(Ubuntu 系统下的文泉驿和文鼎字体)、adobe(Adobe 公司的中文字体)、founder(方正公司的中文字体)，默认根据操作系统自动配置。
 \item 正文字号：cs4size(小四)、c5size(五号)。
 \item 盲审选项：使用review选项后，论文作者、学号、导师姓名、致谢、发表论文和参与项目将被隐去。
 \end{itemize}

--- a/thesis.tex
+++ b/thesis.tex
@@ -4,9 +4,9 @@
 %%==================================================
 
 % 双面打印
-\documentclass[doctor, fontset=fandol, openright, twoside]{sjtuthesis}
-% \documentclass[bachelor, fontset=fandol, openany, oneside, submit]{sjtuthesis}
-% \documentclass[master, fontset=fandol, review]{sjtuthesis}
+\documentclass[doctor, openright, twoside]{sjtuthesis}
+% \documentclass[bachelor, openany, oneside, submit]{sjtuthesis}
+% \documentclass[master, review]{sjtuthesis}
 % \documentclass[%
 %   bachelor|master|doctor,	% 必选项
 %   fontset=fandol|windows|mac|ubuntu|adobe|founder, % 字体选项


### PR DESCRIPTION
CTeX 宏集现在可以自动检测编译方式和操作系统并配置中文字体，建议模版默认使用自动策略，配合 #218 设置西文字体，一般用户在使用模版时可以无需安装额外字体，免去了许多不必要的麻烦。同时保留 `fontset` 作为可选项，供有需要的同学使用。

> [![CTeX](https://camo.githubusercontent.com/7a9e52e4c72bf04ac3b4a51f293b0070b73cfe4c/687474703a2f2f73766773686172652e636f6d2f692f345a392e737667)](https://mirrors.tuna.tsinghua.edu.cn/CTAN/language/chinese/ctex/ctex.pdf)