### PR TITLE
[enhancement] 恢复非上标的引用命令为 \parencite{}

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -78,14 +78,6 @@
 \RequirePackage[list=off]{bicaption}
 \RequirePackage{subcaption}
 \RequirePackage[backend=biber,style=gb7714-2015]{biblatex}
-\DeclareCiteCommand{\citen} %加入一个水平引用函数
-  {[\usebibmacro{cite:init}%直接添加方括号
-   \usebibmacro{prenote}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{cite:comp}}
-  {}
-  {\usebibmacro{cite:dump}%
-   \usebibmacro{postnote}]}
 \RequirePackage{xcolor}
 \RequirePackage{listings}
 \RequirePackage[xetex, bookmarksnumbered, colorlinks, urlcolor=black, linkcolor=black, citecolor=black, plainpages=false, pdfstartview=FitH]{hyperref}

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -350,10 +350,10 @@ i,j作为虚数单位时，也应该使用“直立体”为了明显，还加�
 
 正文中引用参考文献时，用\verb+\cite{key1,key2,key3...}+可以产生“上标引用的参考文献”，
 如\cite{Meta_CN,chen2007act,DPMG}。
-使用\verb+\citen{key1,key2,key3...}+则可以产生水平引用的参考文献，例如\citen{JohnD,zhubajie,IEEE-1363}。
-请看下面的例子，将会穿插使用水平的和上标的参考文献：关于书的\citen{Meta_CN,JohnD,IEEE-1363}，关于期刊的\cite{chen2007act,chen2007ewi}，
-会议论文\citen{DPMG,kocher99,cnproceed}，
-硕士学位论文\citen{zhubajie,metamori2004}，博士学位论文\cite{shaheshang,FistSystem01,bai2008}，标准文件\citen{IEEE-1363}，技术报告\cite{NPB2}，电子文献\citen{xiaoyu2001, CHRISTINE1998}，用户手册\citen{RManual}。
+使用\verb+\parencite{key1,key2,key3...}+则可以产生水平引用的参考文献，例如\parencite{JohnD,zhubajie,IEEE-1363}。
+请看下面的例子，将会穿插使用水平的和上标的参考文献：关于书的\parencite{Meta_CN,JohnD,IEEE-1363}，关于期刊的\cite{chen2007act,chen2007ewi}，
+会议论文\parencite{DPMG,kocher99,cnproceed}，
+硕士学位论文\parencite{zhubajie,metamori2004}，博士学位论文\cite{shaheshang,FistSystem01,bai2008}，标准文件\parencite{IEEE-1363}，技术报告\cite{NPB2}，电子文献\parencite{xiaoyu2001, CHRISTINE1998}，用户手册\parencite{RManual}。
 
 总结一些注意事项：
 \begin{itemize}


### PR DESCRIPTION
**Description:**

恢复非上标的引用命令为 `\parencite{}`

**Related Issues:**
#181 
  