### PR TITLE
.travis.yml: Add travisbuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,7 @@ before_script:
 
 script:
   - make validate
+
+notifications:
+  webhooks: https://www.travisbuddy.com/
+  on_success: never


### PR DESCRIPTION
 TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contributors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed. 

Signed-off-by: Ce Gao <gaoce@caicloud.io>