### PR TITLE
Editor compatibility improvement for SublimeText and TeXShop

### DIFF
--- a/tex/abstract.tex
+++ b/tex/abstract.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% abstract.tex for SJTU Master Thesis
 %%==================================================

--- a/tex/ack.tex
+++ b/tex/ack.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \begin{thanks}
 
   感谢所有测试和使用交大学位论文 \LaTeX 模板的同学！

--- a/tex/app_cjk.tex
+++ b/tex/app_cjk.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \chapter{从 {\CJKLaTeX} 转向 \texorpdfstring{\XeTeX}{XeTeX}}
 \label{chap:whydvipdfm}
 

--- a/tex/app_eq.tex
+++ b/tex/app_eq.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %% app2.tex for SJTU Master Thesis
 %% based on CASthesis
 %% modified by wei.jianwen@gmail.com

--- a/tex/app_log.tex
+++ b/tex/app_log.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \chapter{模板更新记录}
 \label{chap:updatelog}
 

--- a/tex/app_setup.tex
+++ b/tex/app_setup.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \chapter{搭建模板编译环境}
 
 \section{安装TeX发行版}

--- a/tex/end_english_abstract.tex
+++ b/tex/end_english_abstract.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \begin{bigabstract}
 Affronting discretion as do is announcing. Now months esteem oppose nearer enable too six. She numerous unlocked you perceive speedily. Affixed offence spirits or ye of offices between. Real on shot it were four an as. Absolute bachelor rendered six nay you juvenile. Vanity entire an chatty to. 
 

--- a/tex/example.tex
+++ b/tex/example.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% chapter02.tex for SJTU Master Thesis
 %% based on CASthesis

--- a/tex/faq.tex
+++ b/tex/faq.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \chapter{常见问题}
 \label{chap:faq}
 
@@ -46,6 +49,16 @@ A:这是xltxtra和fontspec宏包导致的问题。学位论文模板从0.5起使
 {\bfseries{}Q:为什么在bib中加入的参考文献，没有在参考文献列表中出现?}
 
 A: bib中的参考文献条目，只有通过\verb+\cite+或者\verb+\upcite+在正文中引用，才会加入到参考文献列表中。
+
+{\bfseries{}Q:我可以使用Sublime Text编写学位论文吗？}
+
+A: 可以。首先\href{https://www.sublimetext.com/}{下载}并安装Sublime Text，然后安装
+\href{https://packagecontrol.io/installation}{Package Control}，
+之后按\verb|ctrl+shift+p|或者\verb|cmd+shift+p|调出命令窗口，
+输入\verb|install|，选择\textit{Package Control: Install Package}，按回车，
+稍等片刻，等待索引载入后会弹出选项框，输入\verb|LaTeXTools|并回车，即可成功安装插件。
+之后只需要打开\verb|.tex|文件，按\verb|ctrl+b|或者\verb|cmd+b|即可编译，
+如有错误，双击错误信息可以跳转到出错的行。
 
 {\bfseries{}Q:在macTex中，为什么pdf图片无法插入？}
 

--- a/tex/id.tex
+++ b/tex/id.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \title{上海交通大学学位论文 \LaTeX 模板示例文档}
 \author{某\quad{}某}
 \advisor{某某教授}

--- a/tex/intro.tex
+++ b/tex/intro.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% chapter01.tex for SJTU Master Thesis
 %%==================================================

--- a/tex/patents.tex
+++ b/tex/patents.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \begin{patents}{99}
     \item 第一发明人，“永动机”，专利申请号202510149890.0
 \end{patents}

--- a/tex/projects.tex
+++ b/tex/projects.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% projects.tex for SJTUThesis
 %% Encoding: UTF-8

--- a/tex/projectsreview.tex
+++ b/tex/projectsreview.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 
 \begin{projects}{99}
     \item 参与973项目子课题(2007年6月--2008年5月)

--- a/tex/pub.tex
+++ b/tex/pub.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% pub.tex for SJTUThesis
 %% Encoding: UTF-8

--- a/tex/pubreview.tex
+++ b/tex/pubreview.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 
 \begin{publications}{99}
     \item\textsc{第一作者}. {中文核心期刊论文}, 2007.  

--- a/tex/summary.tex
+++ b/tex/summary.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 %%==================================================
 %% conclusion.tex for SJTUThesis
 %% Encoding: UTF-8

--- a/tex/symbol.tex
+++ b/tex/symbol.tex
@@ -1,4 +1,7 @@
 %# -*- coding: utf-8-unix -*-
+% !TEX program = xelatex
+% !TEX root = ../thesis.tex
+% !TEX encoding = UTF-8 Unicode
 \begin{nomenclaturename}
 \label{chap:symb}
 


### PR DESCRIPTION
1. Specify `TEX program` and `TEX root` so that SublimeText with LaTeXTools can directly build tex files. (ref: <https://latextools.readthedocs.io/en/latest/features/#multi-file-documents>)
2. Specify `TEX encoding` so that TexShop can recognize utf-8 automatically. (ref: <https://tex.stackexchange.com/a/46207>)