### PR TITLE
专业字数过长改为两行显示

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -118,6 +118,7 @@
 \RequirePackage{calc}
 \RequirePackage{algorithm, algorithmicx, algpseudocode}
 \RequirePackage{siunitx}
+\RequirePackage{xstring}
 
 \RequirePackage{tikz}
 \usetikzlibrary{shapes.geometric, arrows}
@@ -402,6 +403,7 @@
 }
 
 % “绘制”中文标题页
+\newcommand\longtextsplitchar{;;}
 \newcommand\makechinesetitle{%
   \cleardoublepage
   \thispagestyle{empty}
@@ -429,7 +431,11 @@
         \sjtu@label@coadvisor     & \underline{\makebox[150pt]{\sjtu@value@coadvisor}} \\ 
       \fi
     \fi
-      \sjtu@label@major         & \underline{\makebox[150pt]{\sjtu@value@major}} \\
+    % 专业字数最多支持两行
+    \IfSubStr{\sjtu@value@major}{\longtextsplitchar}
+      {\sjtu@label@major         & \underline{\makebox[150pt]{\StrBefore{\sjtu@value@major}{\longtextsplitchar}}} \\
+                                 & \underline{\makebox[150pt]{\StrBehind{\sjtu@value@major}{\longtextsplitchar}}} \\}
+      {\sjtu@label@major         & \underline{\makebox[150pt]{\sjtu@value@major}} \\}
       \sjtu@label@defenddate    & \underline{\makebox[150pt]{\sjtu@value@defenddate}}
   \end{tabular}
   \end{center}

--- a/tex/faq.tex
+++ b/tex/faq.tex
@@ -86,3 +86,12 @@ A: 中文无法识别的情况多半是由于使用了 ShareLaTeX 的原因，�
 {\bfseries{}Q:如何向你致谢?}
 
 A: 烦请在模板的\href{https://github.com/sjtug/SJTUThesis}{github主页}点击“Star”，我想粗略统计一下使用学位论文模板的人数，谢谢大家。非常欢迎大家向项目贡献代码。
+
+{\bfseries{}Q:标题中专业名称太长怎么办？}
+
+A: 如果专业名称字数还没有超过两行的话，可以在专业名称需要换号的地方加上英文双分号“\verb|;;|”。如下所示。如果超过两行的话，建议用缩写，或者您继续向我们反馈问题，详情参考\href{https://github.com/sjtug/SJTUThesis/pull/369}{这里}。
+
+\begin{lstlisting}[language={Tex}, caption={标题专业名称太长怎么办}]
+\major{某某专业;;这个专业比较长}
+\end{lstlisting}
+


### PR DESCRIPTION
过长专业改为两行显示，换行处使用`;;`区分。https://github.com/sjtug/SJTUThesis/issues/330