### PR TITLE
添加上交硕士论文模板封面

### DIFF
--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -6,36 +6,18 @@
 \ProvidesFile{sjtuthesis.cfg}[2016/04/06 v0.9 sjtuthesis configuration file]
 
 %% labels in the title page
-\ifsjtu@altcover
+\ifsjtu@master
   \def\sjtu@label@major{学科：}
   \def\sjtu@label@title{论文题目}
   \def\sjtu@label@thesis{学位论文}
   \def\sjtu@label@coadvisor{副导师：}
   \def\sjtu@label@defenddate{答辩日期：}
   \def\sjtu@label@institute{所在单位：}
-  \def\sjtu@label@chinesedegree{申请学位：}
+  \def\sjtu@label@cnacademicdegree{申请学位：}
   \def\sjtu@label@school{授予学位单位：}
-  \ifsjtu@master
-    \def\sjtu@label@author{硕士研究生：}
-    \def\sjtu@label@studentnumber{学号：}
-    \def\sjtu@label@advisor{导师：}
-  \else
-    \ifsjtu@coursepaper
-      \def\sjtu@label@author{姓名：}
-      \def\sjtu@label@studentnumber{学号：}
-      \def\sjtu@label@coursename{课程：}
-    \else
-      \ifsjtu@bachelor
-        \def\sjtu@label@author{学生姓名：}
-        \def\sjtu@label@studentnumber{学生学号：}
-        \def\sjtu@label@advisor{指导教师：}
-      \else
-        \def\sjtu@label@author{论文作者：}
-        \def\sjtu@label@studentnumber{学号：}
-        \def\sjtu@label@advisor{导师：}
-      \fi
-    \fi
-  \fi
+  \def\sjtu@label@author{硕士研究生：}
+  \def\sjtu@label@studentnumber{学号：}
+  \def\sjtu@label@advisor{导师：}
 \else
   \def\sjtu@label@major{专业}
   \def\sjtu@label@title{论文题目}
@@ -87,7 +69,7 @@
       \fi
     \fi
   \fi
-  \ifsjtu@altcover
+  \ifsjtu@master
     \def\sjtu@label@statement{\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
   \else
     \def\sjtu@label@statement{申请\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
@@ -99,28 +81,28 @@
 \def\sjtu@label@authorization{学位论文版权使用授权书}
 \def\sjtu@label@authorsign{学位论文作者签名：}
 \def\sjtu@label@Supervisorsign{指导教师签名：}
-\def\sjtu@label@originalDate{日\hspace{1em}期：\hrulefill\hrulefill 年 \hrulefill 月 \hrulefill 日}
+\def\sjtu@label@originalDate{日期：\hrulefill\hrulefill 年 \hrulefill 月 \hrulefill 日}
 \def\sjtu@label@originalcontent{是本人在导师的指导下， 独立进行研究工作所取得的成果。除文中已经注明引用的内容外，本论文不包含任何其他个人或集体已经发表或撰写过的作品成果。对本文的研究做出重要贡献的个人和集体，均已在文中以明确方式标明。本人完全意识到本声明的法律结果由本人承担。
 }
 \def\sjtu@label@authorizationcontent{本学位论文作者完全了解学校有关保留、使用学位论文的规定，同意学校保留并向国家有关部门或机构送交论文的复印件和电子版，允许论文被查阅和借阅。本人授权上海交通大学可以将本学位论文的全部或部分内容编入有关数据库进行检索，可以采用影印、缩印或扫描等复制手段保存和汇编本学位论文。\par
         本学位论文属于\\
         \hspace*{9em}\textbf{保\hspace{1em}密} $\square$，在~\hrulefill~年解密后适用本授权书。\\
         \hspace*{9em}\textbf{不保密} $\square$。\\
-        （请在以上方框内打$\checked$）
+        （请在以上方框内打“$\checked$”）
 }
 
 %% labels in the english title page
-\ifsjtu@altcover
+\ifsjtu@master
   \def\sjtu@label@englishadvisor{Supervisor:}
   \def\sjtu@label@englishcoadvisor{Co-supervisor:}
   \def\sjtu@label@englishauthor{Candidate:}
   \def\sjtu@label@englishstudentid{Student ID:}
-  \def\sjtu@label@englishdegree{Academic Degree Applied for:}
+  \def\sjtu@label@enacademicdegree{Academic Degree Applied for:}
   \def\sjtu@label@englishmajor{Speciality:}
   \def\sjtu@label@englishinstitute{Affiliation:}
   \def\sjtu@label@englishdate{Date of Defence:}
   \def\sjtu@label@englishschool{Degree-Conferring-Institution:}
-  \def\sjtu@label@englishstatement{Dissertation Submitted to Shanghai Jiao Tong University \\ for the Degree of \sjtu@value@englishdegree}
+  \def\sjtu@label@englishstatement{Dissertation Submitted to Shanghai Jiao Tong University \\[8pt] for the Degree of \sjtu@value@englishdegree}
 \else
   \def\sjtu@label@englishadvisor{Advisor}
   \def\sjtu@label@englishcoadvisor{Co-advisor}
@@ -186,9 +168,14 @@
 \def\sjtu@label@abstract{\sjtu@label@chineseabstract}
 \def\sjtu@contentsname{目~~~~录}
 \def\sjtu@figurename{图}
-\def\sjtu@listfigurename{插图索引}
+\ifsjtu@master
+  \def\sjtu@listfigurename{图~~录}
+  \def\sjtu@listtablename{表~~录}
+\else
+  \def\sjtu@listfigurename{插图索引}
+  \def\sjtu@listtablename{表格索引}
+\fi
 \def\sjtu@tablename{表}
-\def\sjtu@listtablename{表格索引}
 \def\sjtu@algorithmicrequire{输入:}
 \def\sjtu@algorithmicensure{输出:}
 \def\sjtu@listalgorithmname{算法索引}

--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -99,7 +99,7 @@
   \def\sjtu@label@englishstudentid{Student ID:}
   \def\sjtu@label@enacademicdegree{Academic Degree Applied for:}
   \def\sjtu@label@englishmajor{Speciality:}
-  \def\sjtu@label@englishinstitute{Affiliation:}
+  \def\sjtu@label@englishmasterinstitute{Affiliation:}
   \def\sjtu@label@englishdate{Date of Defence:}
   \def\sjtu@label@englishschool{Degree-Conferring-Institution:}
   \def\sjtu@label@englishstatement{Dissertation Submitted to Shanghai Jiao Tong University \\[8pt] for the Degree of \sjtu@value@englishdegree}

--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -6,26 +6,58 @@
 \ProvidesFile{sjtuthesis.cfg}[2016/04/06 v0.9 sjtuthesis configuration file]
 
 %% labels in the title page
-\def\sjtu@label@major{专业}
-\def\sjtu@label@title{论文题目}
-\def\sjtu@label@thesis{学位论文}
-\def\sjtu@label@coadvisor{副导师}
-\def\sjtu@label@defenddate{答辩日期}
-\def\sjtu@label@institute{学院(系)}
-\def\sjtu@label@coursepaper{课程论文}
-\ifsjtu@bachelor
-  \def\sjtu@label@author{学生姓名}
-  \def\sjtu@label@studentnumber{学生学号}
-  \def\sjtu@label@advisor{指导教师}
-\else
-  \ifsjtu@coursepaper
-    \def\sjtu@label@author{姓名}
-    \def\sjtu@label@studentnumber{学号}
-    \def\sjtu@label@coursename{课程}
+\ifsjtu@altcover
+  \def\sjtu@label@major{学科：}
+  \def\sjtu@label@title{论文题目}
+  \def\sjtu@label@thesis{学位论文}
+  \def\sjtu@label@coadvisor{副导师：}
+  \def\sjtu@label@defenddate{答辩日期：}
+  \def\sjtu@label@institute{所在单位：}
+  \def\sjtu@label@chinesedegree{申请学位：}
+  \def\sjtu@label@school{授予学位单位：}
+  \ifsjtu@master
+    \def\sjtu@label@author{硕士研究生：}
+    \def\sjtu@label@studentnumber{学号：}
+    \def\sjtu@label@advisor{导师：}
   \else
-    \def\sjtu@label@author{论文作者}
-    \def\sjtu@label@studentnumber{学号}
-    \def\sjtu@label@advisor{导师}
+    \ifsjtu@coursepaper
+      \def\sjtu@label@author{姓名：}
+      \def\sjtu@label@studentnumber{学号：}
+      \def\sjtu@label@coursename{课程：}
+    \else
+      \ifsjtu@bachelor
+        \def\sjtu@label@author{学生姓名：}
+        \def\sjtu@label@studentnumber{学生学号：}
+        \def\sjtu@label@advisor{指导教师：}
+      \else
+        \def\sjtu@label@author{论文作者：}
+        \def\sjtu@label@studentnumber{学号：}
+        \def\sjtu@label@advisor{导师：}
+      \fi
+    \fi
+  \fi
+\else
+  \def\sjtu@label@major{专业}
+  \def\sjtu@label@title{论文题目}
+  \def\sjtu@label@thesis{学位论文}
+  \def\sjtu@label@coadvisor{副导师}
+  \def\sjtu@label@defenddate{答辩日期}
+  \def\sjtu@label@institute{学院(系)}
+  \def\sjtu@label@coursepaper{课程论文}
+  \ifsjtu@bachelor
+    \def\sjtu@label@author{学生姓名}
+    \def\sjtu@label@studentnumber{学生学号}
+    \def\sjtu@label@advisor{指导教师}
+  \else
+    \ifsjtu@coursepaper
+      \def\sjtu@label@author{姓名}
+      \def\sjtu@label@studentnumber{学号}
+      \def\sjtu@label@coursename{课程}
+    \else
+      \def\sjtu@label@author{论文作者}
+      \def\sjtu@label@studentnumber{学号}
+      \def\sjtu@label@advisor{导师}
+    \fi
   \fi
 \fi
 
@@ -55,7 +87,11 @@
       \fi
     \fi
   \fi
-  \def\sjtu@label@statement{申请\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+  \ifsjtu@altcover
+    \def\sjtu@label@statement{\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+  \else
+    \def\sjtu@label@statement{申请\sjtu@value@school\sjtu@value@chinesedegree\sjtu@label@thesis}
+  \fi
 \fi
 
 %% 论文原创性声明
@@ -64,7 +100,7 @@
 \def\sjtu@label@authorsign{学位论文作者签名：}
 \def\sjtu@label@Supervisorsign{指导教师签名：}
 \def\sjtu@label@originalDate{日\hspace{1em}期：\hrulefill\hrulefill 年 \hrulefill 月 \hrulefill 日}
-\def\sjtu@label@originalcontent{本人郑重声明：所呈交的学位论文，是本人在导师的指导下， 独立进行研究工作所取得的成果。除文中已经注明引用的内容外，本论文不包含任何其他个人或集体已经发表或撰写过的作品成果。对本文的研究做出重要贡献的个人和集体，均已在文中以明确方式标明。本人完全意识到本声明的法律结果由本人承担。
+\def\sjtu@label@originalcontent{是本人在导师的指导下， 独立进行研究工作所取得的成果。除文中已经注明引用的内容外，本论文不包含任何其他个人或集体已经发表或撰写过的作品成果。对本文的研究做出重要贡献的个人和集体，均已在文中以明确方式标明。本人完全意识到本声明的法律结果由本人承担。
 }
 \def\sjtu@label@authorizationcontent{本学位论文作者完全了解学校有关保留、使用学位论文的规定，同意学校保留并向国家有关部门或机构送交论文的复印件和电子版，允许论文被查阅和借阅。本人授权上海交通大学可以将本学位论文的全部或部分内容编入有关数据库进行检索，可以采用影印、缩印或扫描等复制手段保存和汇编本学位论文。\par
         本学位论文属于\\
@@ -74,11 +110,24 @@
 }
 
 %% labels in the english title page
-\def\sjtu@label@englishadvisor{Advisor}
-\def\sjtu@label@englishcoadvisor{Co-advisor}
-\def\sjtu@label@englishstatement{Submitted in total fulfillment
-  of the requirements for the degree of \sjtu@value@englishdegree \\
-  in \sjtu@value@englishmajor}
+\ifsjtu@altcover
+  \def\sjtu@label@englishadvisor{Supervisor:}
+  \def\sjtu@label@englishcoadvisor{Co-supervisor:}
+  \def\sjtu@label@englishauthor{Candidate:}
+  \def\sjtu@label@englishstudentid{Student ID:}
+  \def\sjtu@label@englishdegree{Academic Degree Applied for:}
+  \def\sjtu@label@englishmajor{Speciality:}
+  \def\sjtu@label@englishinstitute{Affiliation:}
+  \def\sjtu@label@englishdate{Date of Defence:}
+  \def\sjtu@label@englishschool{Degree-Conferring-Institution:}
+  \def\sjtu@label@englishstatement{Dissertation Submitted to Shanghai Jiao Tong University \\ for the Degree of \sjtu@value@englishdegree}
+\else
+  \def\sjtu@label@englishadvisor{Advisor}
+  \def\sjtu@label@englishcoadvisor{Co-advisor}
+  \def\sjtu@label@englishstatement{Submitted in total fulfillment
+    of the requirements for the degree of \sjtu@value@englishdegree \\
+    in \sjtu@value@englishmajor}
+\fi
 
 %% labels in the abstracts
 \def\sjtu@label@chineseabstract{摘~~~~要}

--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -99,7 +99,7 @@
   \def\sjtu@label@englishstudentid{Student ID:}
   \def\sjtu@label@enacademicdegree{Academic Degree Applied for:}
   \def\sjtu@label@englishmajor{Speciality:}
-  \def\sjtu@label@englishmasterinstitute{Affiliation:}
+  \def\sjtu@label@englishinstitutemaster{Affiliation:}
   \def\sjtu@label@englishdate{Date of Defence:}
   \def\sjtu@label@englishschool{Degree-Conferring-Institution:}
   \def\sjtu@label@englishstatement{Dissertation Submitted to Shanghai Jiao Tong University \\[8pt] for the Degree of \sjtu@value@englishdegree}

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -13,6 +13,7 @@
 \newif\ifsjtu@english\sjtu@englishfalse
 \newif\ifsjtu@review\sjtu@reviewfalse
 \newif\ifsjtu@submit\sjtu@submitfalse
+\newif\ifsjtu@altcover\sjtu@altcoverfalse
 \DeclareOption{coursepaper}{\sjtu@coursepapertrue}
 \DeclareOption{bachelor}{\sjtu@bachelortrue}
 \DeclareOption{master}{\sjtu@mastertrue}
@@ -20,6 +21,7 @@
 \DeclareOption{english}{\sjtu@englishtrue}
 \DeclareOption{review}{\sjtu@reviewtrue}
 \DeclareOption{submit}{\sjtu@submittrue}
+\DeclareOption{altcover}{\sjtu@altcovertrue}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
 \ifsjtu@english
@@ -88,6 +90,7 @@
 \newcommand\englishdate[1]{\def\sjtu@value@englishdate{#1}}
 \newcommand\englishdegree[1]{\def\sjtu@value@englishdegree{#1}}
 \newcommand\englishmajor[1]{\def\sjtu@value@englishmajor{#1}}
+\newcommand\englishstudentid[1]{\def\sjtu@value@englishstudentid{#1}}
 \newcommand\englishkeywords[1]{\def\sjtu@value@englishkeywords{#1}}
 
 %==========
@@ -129,6 +132,7 @@
 \RequirePackage{siunitx}
 \RequirePackage{xparse}
 \RequirePackage{tikz}
+\RequirePackage{makecell}
 \usetikzlibrary{shapes.geometric, arrows}
 
 % Make hyperref to set PDF metadata (author, title, subject, keywords)
@@ -420,8 +424,13 @@
     \ifsjtu@bachelor
       \makechinesetitle@bachelor
     \else
-      \makechinesetitle
-      \makeenglishtitle
+      \ifsjtu@altcover
+        \makechinesetitle@altcover
+        \makeenglishtitle@altcover
+      \else
+        \makechinesetitle
+        \makeenglishtitle
+      \fi
     \fi
   \fi
 }
@@ -442,6 +451,85 @@
     \seq_map_inline:Nn \l__sjtu_tmp_seq { ##1 }
   }
 \ExplSyntaxOff
+
+% “绘制”硕士论文模板中文标题页
+\newcommand\makechinesetitle@altcover{%
+  \cleardoublepage
+  \thispagestyle{empty}
+  \begin{center}
+  {\songti\zihao{-2}\sjtu@label@statement}
+  \vskip\stretch{1}
+  {\heiti\zihao{2}\sjtu@value@chinesetitle}
+  \vskip\stretch{1}
+  {\fangsong\zihao{4}}
+  \zihao{4}
+  \def\tabcolsep{1pt}
+  \def\arraystretch{1.5}
+  \begin{tabular}{>{\begin{CJKfilltwosides}[t]{7\ccwd}\heiti }r<{\end{CJKfilltwosides}}l}
+    \ifsjtu@review
+      \sjtu@label@author        & \enspace ~ \\
+      \sjtu@label@studentnumber & \enspace ~ \\
+      \sjtu@label@advisor       & \enspace ~ \\
+      \ifx\sjtu@value@coadvisor\undefined\else
+        \sjtu@label@coadvisor     & \enspace ~ \\
+      \fi
+    \else
+      \sjtu@label@author        & \enspace {\sjtu@value@author} \\
+      \sjtu@label@studentnumber & \enspace {\sjtu@value@studentnumber} \\
+      \sjtu@label@advisor       & \enspace {\sjtu@value@advisor} \\
+      \ifx\sjtu@value@coadvisor\undefined\else
+        \sjtu@label@coadvisor     & \enspace {\sjtu@value@coadvisor} \\
+      \fi
+    \fi
+      \sjtu@label@chinesedegree   & \enspace {\sjtu@value@chinesedegree} \\
+      \sjtu@label@major         & \enspace {\sjtu@value@major} \\
+      \sjtu@label@institute         & \enspace {\sjtu@value@institute} \\
+      \sjtu@label@defenddate    & \enspace {\sjtu@value@defenddate} \\
+      \sjtu@label@school        & \enspace {\sjtu@value@school}
+  \end{tabular}
+  \end{center}
+  \vskip \stretch{0.5}
+  \cleardoublepage
+}
+% “绘制”硕士论文模板英文标题页
+\newcommand\makeenglishtitle@altcover{%
+  \cleardoublepage
+  \thispagestyle{empty}
+  \begin{center}
+      {\normalfont\zihao{-2} \sjtu@label@englishstatement}
+      \vspace{20pt} \vskip\stretch{1}
+      {\zihao{2} \textbf{\MakeUppercase{\sjtu@value@englishtitle}} \vskip 1pt}
+      \vskip \stretch{1}
+      {\normalfont\zihao{4}}
+      \zihao{4}
+      \def\tabcolsep{1pt}
+      \def\arraystretch{1.5}
+      \begin{tabular}{ll}
+        \ifsjtu@review
+          \textbf{\sjtu@label@englishauthor} & \enspace ~ \\
+          \textbf{\sjtu@label@englishstudentid} & \enspace ~ \\
+          \textbf{\sjtu@label@englishadvisor}       & \enspace ~ \\
+          \ifx\sjtu@value@englishcoadvisor\undefined\else
+            \textbf{\sjtu@label@englishcoadvisor}     & \enspace ~ \\
+          \fi
+        \else
+          \textbf{\sjtu@label@englishauthor} & \enspace \sjtu@value@englishauthor \\
+          \textbf{\sjtu@label@englishstudentid} & \enspace \sjtu@value@englishstudentid \\
+          \textbf{\sjtu@label@englishadvisor}      & \enspace \sjtu@value@englishadvisor \\
+          \ifx\sjtu@value@englishcoadvisor\undefined\else
+            \textbf{\sjtu@label@englishcoadvisor}    & \enspace \sjtu@value@englishcoadvisor \\
+          \fi
+        \fi
+        \textbf{\sjtu@label@englishdegree}   & \enspace \sjtu@value@englishdegree \\
+        \textbf{\sjtu@label@englishmajor}         & \enspace \sjtu@value@englishmajor \\
+        \textbf{\sjtu@label@englishinstitute}        & \enspace \makecell[l]{\sjtu@value@englishinstitute} \\
+        \textbf{\sjtu@label@englishdate}    & \enspace \sjtu@value@englishdate \\
+        \textbf{\sjtu@label@englishschool}        & \enspace \sjtu@value@englishschool
+      \end{tabular}
+  \end{center}
+  \vskip \stretch{0.5}
+  \cleardoublepage
+}
 
 % “绘制”中文标题页
 \newcommand\makechinesetitle{%
@@ -601,7 +689,7 @@
     {\zihao{3}\bfseries\heiti \sjtu@label@original}
   \end{center}
   \vskip 10pt
-  {\par\zihao{-4}\sjtu@label@originalcontent\par}
+  {\par\zihao{-4}本人郑重声明：所呈交的学位论文《\sjtu@value@chinesetitle》，\sjtu@label@originalcontent\par}
   \vskip 60pt
   \hspace{13em}\sjtu@label@authorsign\hrulefill\hspace{1.5em}
   \vskip 15pt
@@ -752,7 +840,7 @@
     \vskip 20pt
     \sjtu@label@chineseabstract
   }
-  \markboth{\sjtu@label@chineseabstract}{}
+  \zihao{4} \markboth{\sjtu@label@chineseabstract}{}
 }{
   \vspace{2ex}\noindent
   {\zihao{4} \textbf{\sjtu@label@keywords}{\sjtu@value@keywords}}
@@ -764,7 +852,7 @@
     \vskip 20pt
     \MakeUppercase\sjtu@label@englishabstract
   }
-  \markboth{\sjtu@label@englishabstract}{}
+  \zihao{4} \markboth{\sjtu@label@englishabstract}{}
 }{
   \vspace{2ex}\noindent
   {\zihao{4} \textbf{\sjtu@label@englishkeywords}{\sjtu@value@englishkeywords}}

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -308,14 +308,14 @@
 % 图表索引前加下“图”，“表”关键词
 \ifsjtu@master
   \renewcommand*\cftfigpresnum{\sjtu@figurename~}
-  \newlength{\sjtu@cftfignumwidth@tmp}
-  \settowidth{\sjtu@cftfignumwidth@tmp}{\cftfigpresnum}
-  \addtolength{\cftfignumwidth}{\sjtu@cftfignumwidth@tmp}
+  % \newlength{\sjtu@cftfignumwidth@tmp}
+  % \settowidth{\sjtu@cftfignumwidth@tmp}{\cftfigpresnum}
+  % \addtolength{\cftfignumwidth}{\sjtu@cftfignumwidth@tmp}
   \renewcommand{\cftfigaftersnumb}{\enspace~}
   \renewcommand*\cfttabpresnum{\sjtu@tablename~}
-  \newlength{\sjtu@cfttabnumwidth@tmp}
-  \settowidth{\sjtu@cfttabnumwidth@tmp}{\cfttabpresnum}
-  \addtolength{\cfttabnumwidth}{\sjtu@cfttabnumwidth@tmp}
+  % \newlength{\sjtu@cfttabnumwidth@tmp}
+  % \settowidth{\sjtu@cfttabnumwidth@tmp}{\cfttabpresnum}
+  % \addtolength{\cfttabnumwidth}{\sjtu@cfttabnumwidth@tmp}
   \renewcommand{\cfttabaftersnumb}{\enspace~}
 \fi
 % 使用enumitem宏包配制列表环境

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -86,6 +86,7 @@
 \newcommand\englishcoadvisor[1]{\def\sjtu@value@englishcoadvisor{#1}}
 \newcommand\englishschool[1]{\def\sjtu@value@englishschool{#1}}
 \newcommand\englishinstitute[1]{\def\sjtu@value@englishinstitute{#1}}
+\newcommand\englishmasterinstitute[1]{\def\sjtu@value@englishmasterinstitute{#1}}
 \newcommand\englishdate[1]{\def\sjtu@value@englishdate{#1}}
 \newcommand\englishdegree[1]{\def\sjtu@value@englishdegree{#1}}
 \newcommand\englishmajor[1]{\def\sjtu@value@englishmajor{#1}}
@@ -520,9 +521,9 @@
             \textbf{\sjtu@label@englishcoadvisor}    & \enspace \sjtu@value@englishcoadvisor \\
           \fi
         \fi
-        \textbf{\sjtu@label@enacademicdegree}   & \enspace \sjtu@value@cnacademicdegree \\
+        \textbf{\sjtu@label@enacademicdegree}   & \enspace \sjtu@value@enacademicdegree \\
         \textbf{\sjtu@label@englishmajor}         & \enspace \sjtu@value@englishmajor \\
-        \textbf{\sjtu@label@englishinstitute}        & \enspace \makecell[l]{\sjtu@value@englishinstitute} \\
+        \textbf{\sjtu@label@englishmasterinstitute}        & \enspace \makecell[l]{\sjtu@value@englishmasterinstitute} \\
         \textbf{\sjtu@label@englishdate}    & \enspace \sjtu@value@englishdate \\
         \textbf{\sjtu@label@englishschool}        & \enspace \sjtu@value@englishschool
       \end{tabular}

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -305,6 +305,19 @@
   \renewcommand{\thelstlisting}{\thechapter--\arabic{lstlisting}}
 }
 
+% 图表索引前加下“图”，“表”关键词
+\ifsjtu@master
+  \renewcommand*\cftfigpresnum{\sjtu@figurename~}
+  \newlength{\sjtu@cftfignumwidth@tmp}
+  \settowidth{\sjtu@cftfignumwidth@tmp}{\cftfigpresnum}
+  \addtolength{\cftfignumwidth}{\sjtu@cftfignumwidth@tmp}
+  \renewcommand{\cftfigaftersnumb}{\enspace~}
+  \renewcommand*\cfttabpresnum{\sjtu@tablename~}
+  \newlength{\sjtu@cfttabnumwidth@tmp}
+  \settowidth{\sjtu@cfttabnumwidth@tmp}{\cfttabpresnum}
+  \addtolength{\cfttabnumwidth}{\sjtu@cfttabnumwidth@tmp}
+  \renewcommand{\cfttabaftersnumb}{\enspace~}
+\fi
 % 使用enumitem宏包配制列表环境
 % 紧凑间距
 \setlist{nosep}

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -13,7 +13,6 @@
 \newif\ifsjtu@english\sjtu@englishfalse
 \newif\ifsjtu@review\sjtu@reviewfalse
 \newif\ifsjtu@submit\sjtu@submitfalse
-\newif\ifsjtu@altcover\sjtu@altcoverfalse
 \DeclareOption{coursepaper}{\sjtu@coursepapertrue}
 \DeclareOption{bachelor}{\sjtu@bachelortrue}
 \DeclareOption{master}{\sjtu@mastertrue}
@@ -21,7 +20,6 @@
 \DeclareOption{english}{\sjtu@englishtrue}
 \DeclareOption{review}{\sjtu@reviewtrue}
 \DeclareOption{submit}{\sjtu@submittrue}
-\DeclareOption{altcover}{\sjtu@altcovertrue}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
 \ifsjtu@english
@@ -79,6 +77,7 @@
 \newcommand\institute[1]{\def\sjtu@value@institute{#1}}
 \newcommand\chairman[1]{\def\sjtu@value@chairman{#1}}
 \newcommand\keywords[1]{\def\sjtu@value@keywords{#1}}
+\newcommand\cnacademicdegree[1]{\def\sjtu@value@cnacademicdegree{#1}}
 
 % English variables
 \newcommand\englishtitle[1]{\def\sjtu@value@englishtitle{#1}}
@@ -92,6 +91,7 @@
 \newcommand\englishmajor[1]{\def\sjtu@value@englishmajor{#1}}
 \newcommand\englishstudentid[1]{\def\sjtu@value@englishstudentid{#1}}
 \newcommand\englishkeywords[1]{\def\sjtu@value@englishkeywords{#1}}
+\newcommand\enacademicdegree[1]{\def\sjtu@value@enacademicdegree{#1}}
 
 %==========
 % Segment 1. Import LaTeX packages.
@@ -424,9 +424,9 @@
     \ifsjtu@bachelor
       \makechinesetitle@bachelor
     \else
-      \ifsjtu@altcover
-        \makechinesetitle@altcover
-        \makeenglishtitle@altcover
+      \ifsjtu@master
+        \makechinesetitle@master
+        \makeenglishtitle@master
       \else
         \makechinesetitle
         \makeenglishtitle
@@ -453,18 +453,18 @@
 \ExplSyntaxOff
 
 % “绘制”硕士论文模板中文标题页
-\newcommand\makechinesetitle@altcover{%
+\newcommand\makechinesetitle@master{%
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-  {\songti\zihao{-2}\sjtu@label@statement}
+  {\songti\zihao{-2} ~\\[35pt] \sjtu@label@statement}
   \vskip\stretch{1}
   {\heiti\zihao{2}\sjtu@value@chinesetitle}
-  \vskip\stretch{1}
+  \vskip\stretch{1.2}
   {\fangsong\zihao{4}}
   \zihao{4}
   \def\tabcolsep{1pt}
-  \def\arraystretch{1.5}
+  \def\arraystretch{1.25}
   \begin{tabular}{>{\begin{CJKfilltwosides}[t]{7\ccwd}\heiti }r<{\end{CJKfilltwosides}}l}
     \ifsjtu@review
       \sjtu@label@author        & \enspace ~ \\
@@ -481,29 +481,29 @@
         \sjtu@label@coadvisor     & \enspace {\sjtu@value@coadvisor} \\
       \fi
     \fi
-      \sjtu@label@chinesedegree   & \enspace {\sjtu@value@chinesedegree} \\
+      \sjtu@label@cnacademicdegree & \enspace {\sjtu@value@cnacademicdegree } \\
       \sjtu@label@major         & \enspace {\sjtu@value@major} \\
       \sjtu@label@institute         & \enspace {\sjtu@value@institute} \\
       \sjtu@label@defenddate    & \enspace {\sjtu@value@defenddate} \\
       \sjtu@label@school        & \enspace {\sjtu@value@school}
   \end{tabular}
   \end{center}
-  \vskip \stretch{0.5}
+  \vskip \stretch{0.25}
   \cleardoublepage
 }
 % “绘制”硕士论文模板英文标题页
-\newcommand\makeenglishtitle@altcover{%
+\newcommand\makeenglishtitle@master{%
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-      {\normalfont\zihao{-2} \sjtu@label@englishstatement}
-      \vspace{20pt} \vskip\stretch{1}
+      {\normalfont\zihao{-2} ~\\[35pt] \sjtu@label@englishstatement}
+      \vskip\stretch{1}
       {\zihao{2} \textbf{\MakeUppercase{\sjtu@value@englishtitle}} \vskip 1pt}
       \vskip \stretch{1}
       {\normalfont\zihao{4}}
       \zihao{4}
       \def\tabcolsep{1pt}
-      \def\arraystretch{1.5}
+      \def\arraystretch{1.3}
       \begin{tabular}{ll}
         \ifsjtu@review
           \textbf{\sjtu@label@englishauthor} & \enspace ~ \\
@@ -520,14 +520,14 @@
             \textbf{\sjtu@label@englishcoadvisor}    & \enspace \sjtu@value@englishcoadvisor \\
           \fi
         \fi
-        \textbf{\sjtu@label@englishdegree}   & \enspace \sjtu@value@englishdegree \\
+        \textbf{\sjtu@label@enacademicdegree}   & \enspace \sjtu@value@cnacademicdegree \\
         \textbf{\sjtu@label@englishmajor}         & \enspace \sjtu@value@englishmajor \\
         \textbf{\sjtu@label@englishinstitute}        & \enspace \makecell[l]{\sjtu@value@englishinstitute} \\
         \textbf{\sjtu@label@englishdate}    & \enspace \sjtu@value@englishdate \\
         \textbf{\sjtu@label@englishschool}        & \enspace \sjtu@value@englishschool
       \end{tabular}
   \end{center}
-  \vskip \stretch{0.5}
+  \vskip \stretch{0.4}
   \cleardoublepage
 }
 
@@ -685,15 +685,17 @@
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-    {\zihao{3}\bfseries\heiti \sjtu@value@school} \\
-    {\zihao{3}\bfseries\heiti \sjtu@label@original}
+    ~\\[70pt]
+    % \linespread{1.5}
+    {\zihao{-2}\heiti \textbf{\sjtu@value@school}} \\[12pt]
+    {\zihao{-2}\heiti \textbf{\sjtu@label@original}} \\[12pt]
   \end{center}
   \vskip 10pt
-  {\par\zihao{-4}本人郑重声明：所呈交的学位论文《\sjtu@value@chinesetitle》，\sjtu@label@originalcontent\par}
-  \vskip 60pt
-  \hspace{13em}\sjtu@label@authorsign\hrulefill\hspace{1.5em}
-  \vskip 15pt
-  \hspace{16em}\sjtu@label@originalDate\hspace{1em}
+  {\par\linespread{2}\zihao{4}本人郑重声明：所呈交的学位论文《\sjtu@value@chinesetitle》，\sjtu@label@originalcontent\par}
+  \vskip 80pt
+  {\zihao{4}\hspace{13em}\sjtu@label@authorsign\hrulefill\hspace{1.5em}}
+  \vskip 40pt
+  {\zihao{4}\hspace{11em}\sjtu@label@originalDate\hspace{1em}}
   \cleardoublepage
 }
 
@@ -702,15 +704,16 @@
   \cleardoublepage
   \thispagestyle{empty}
   \begin{center}
-    {\zihao{3}\bfseries\heiti \sjtu@value@school} \\
-    {\zihao{3}\bfseries\heiti \sjtu@label@authorization}
+    ~\\[30pt]
+    {\zihao{-2}\bfseries\heiti \sjtu@value@school} \\[12pt]
+    {\zihao{-2}\bfseries\heiti \sjtu@label@authorization} \\[12pt]
   \end{center}
   \vskip 10pt
-  {\par\zihao{-4}\sjtu@label@authorizationcontent\par}
-  \vskip 60pt
-  \sjtu@label@authorsign\hrulefill\hspace{3em}\sjtu@label@Supervisorsign\hrulefill
-  \vskip 15pt
-  \sjtu@label@originalDate\hfill\hspace{3em}\sjtu@label@originalDate
+  {\par\linespread{1.5}\zihao{4}\sjtu@label@authorizationcontent\par}
+  \vskip 150pt
+  {\zihao{4} \sjtu@label@authorsign\hrulefill\hspace{3em}\sjtu@label@Supervisorsign\hrulefill}
+  \vskip 40pt
+  {\zihao{4} \sjtu@label@originalDate\hfill\hspace{3em}\sjtu@label@originalDate}
   \cleardoublepage
 }
 

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -86,7 +86,7 @@
 \newcommand\englishcoadvisor[1]{\def\sjtu@value@englishcoadvisor{#1}}
 \newcommand\englishschool[1]{\def\sjtu@value@englishschool{#1}}
 \newcommand\englishinstitute[1]{\def\sjtu@value@englishinstitute{#1}}
-\newcommand\englishmasterinstitute[1]{\def\sjtu@value@englishmasterinstitute{#1}}
+\newcommand\englishinstitutemaster[1]{\def\sjtu@value@englishinstitutemaster{#1}}
 \newcommand\englishdate[1]{\def\sjtu@value@englishdate{#1}}
 \newcommand\englishdegree[1]{\def\sjtu@value@englishdegree{#1}}
 \newcommand\englishmajor[1]{\def\sjtu@value@englishmajor{#1}}
@@ -536,7 +536,7 @@
         \fi
         \textbf{\sjtu@label@enacademicdegree}   & \enspace \sjtu@value@enacademicdegree \\
         \textbf{\sjtu@label@englishmajor}         & \enspace \sjtu@value@englishmajor \\
-        \textbf{\sjtu@label@englishmasterinstitute}        & \enspace \makecell[l]{\sjtu@value@englishmasterinstitute} \\
+        \textbf{\sjtu@label@englishinstitutemaster}        & \enspace \makecell[l]{\sjtu@value@englishinstitutemaster} \\
         \textbf{\sjtu@label@englishdate}    & \enspace \sjtu@value@englishdate \\
         \textbf{\sjtu@label@englishschool}        & \enspace \sjtu@value@englishschool
       \end{tabular}

--- a/tex/id.tex
+++ b/tex/id.tex
@@ -24,7 +24,7 @@
 \englishinstitute{\textsc{Depart of XXX, School of XXX} \\
   \textsc{Shanghai Jiao Tong University} \\
   \textsc{Shanghai, P.R.China}}
-\englishmasterinstitute{Depart of XXX, \\ School of XXX}
+\englishinstitutemaster{Depart of XXX, \\ School of XXX}
 \englishmajor{A Very Important Major}
 \englishdate{Dec. 17th, 2014}
 \enacademicdegree{Master of Engineering}

--- a/tex/id.tex
+++ b/tex/id.tex
@@ -12,11 +12,11 @@
 \school{上海交通大学}
 \institute{某某系}
 \studentnumber{0010900990}
-\chinesedegree{工学硕士}
+\cnacademicdegree{工学硕士}
 \major{某某专业}
 \keywords{上海交大, 饮水思源, 爱国荣校}
 
-\englishtitle{A Sample Document for \LaTeX-basedd SJTU Thesis Template}
+\englishtitle{A Sample Document for \LaTeX-based SJTU Thesis Template}
 \englishauthor{\textsc{Mo Mo}}
 \englishadvisor{Prof. \textsc{Mou Mou}}
 % \englishcoadvisor{Prof. \textsc{Uom Uom}}
@@ -27,7 +27,7 @@
 \englishinstitute{Depart of XXX, \\ School of XXX}
 \englishmajor{A Very Important Major}
 \englishdate{Dec. 17th, 2014}
-\englishdegree{Master of Engineering}
+\enacademicdegree{Master of Engineering}
 \englishstudentid{0010900990}
 \englishkeywords{SJTU, master thesis, XeTeX/LaTeX template}
 %TC:endignore

--- a/tex/id.tex
+++ b/tex/id.tex
@@ -21,10 +21,10 @@
 \englishadvisor{Prof. \textsc{Mou Mou}}
 % \englishcoadvisor{Prof. \textsc{Uom Uom}}
 \englishschool{Shanghai Jiao Tong University}
-% \englishinstitute{\textsc{Depart of XXX, School of XXX} \\
-%   \textsc{Shanghai Jiao Tong University} \\
-%   \textsc{Shanghai, P.R.China}}
-\englishinstitute{Depart of XXX, \\ School of XXX}
+\englishinstitute{\textsc{Depart of XXX, School of XXX} \\
+  \textsc{Shanghai Jiao Tong University} \\
+  \textsc{Shanghai, P.R.China}}
+\englishmasterinstitute{Depart of XXX, \\ School of XXX}
 \englishmajor{A Very Important Major}
 \englishdate{Dec. 17th, 2014}
 \enacademicdegree{Master of Engineering}

--- a/tex/id.tex
+++ b/tex/id.tex
@@ -12,6 +12,7 @@
 \school{上海交通大学}
 \institute{某某系}
 \studentnumber{0010900990}
+\chinesedegree{工学硕士}
 \major{某某专业}
 \keywords{上海交大, 饮水思源, 爱国荣校}
 
@@ -20,10 +21,13 @@
 \englishadvisor{Prof. \textsc{Mou Mou}}
 % \englishcoadvisor{Prof. \textsc{Uom Uom}}
 \englishschool{Shanghai Jiao Tong University}
-\englishinstitute{\textsc{Depart of XXX, School of XXX} \\
-  \textsc{Shanghai Jiao Tong University} \\
-  \textsc{Shanghai, P.R.China}}
+% \englishinstitute{\textsc{Depart of XXX, School of XXX} \\
+%   \textsc{Shanghai Jiao Tong University} \\
+%   \textsc{Shanghai, P.R.China}}
+\englishinstitute{Depart of XXX, \\ School of XXX}
 \englishmajor{A Very Important Major}
 \englishdate{Dec. 17th, 2014}
+\englishdegree{Master of Engineering}
+\englishstudentid{0010900990}
 \englishkeywords{SJTU, master thesis, XeTeX/LaTeX template}
 %TC:endignore

--- a/thesis.tex
+++ b/thesis.tex
@@ -4,7 +4,7 @@
 %%==================================================
 
 % 双面打印
-\documentclass[doctor, openright, twoside]{sjtuthesis}
+\documentclass[doctor, openright, twoside, altcover]{sjtuthesis}
 % \documentclass[bachelor, openany, oneside, submit]{sjtuthesis}
 % \documentclass[master, review]{sjtuthesis}
 % \documentclass[%
@@ -15,6 +15,7 @@
 %   english,                % 启用英文模版
 %   review,     % 盲审论文，隐去作者姓名、学号、导师姓名、致谢、发表论文和参与的项目
 %   submit      % 定稿提交的论文，插入签名扫描版的原创性声明、授权声明
+%   altcover    % 上海交通大学硕士论文模板封面
 % ]
 
 % 逐个导入参考文献数据库

--- a/thesis.tex
+++ b/thesis.tex
@@ -4,7 +4,7 @@
 %%==================================================
 
 % 双面打印
-\documentclass[doctor, openright, twoside, altcover]{sjtuthesis}
+\documentclass[master, openright, twoside]{sjtuthesis}
 % \documentclass[bachelor, openany, oneside, submit]{sjtuthesis}
 % \documentclass[master, review]{sjtuthesis}
 % \documentclass[%
@@ -15,7 +15,6 @@
 %   english,                % 启用英文模版
 %   review,     % 盲审论文，隐去作者姓名、学号、导师姓名、致谢、发表论文和参与的项目
 %   submit      % 定稿提交的论文，插入签名扫描版的原创性声明、授权声明
-%   altcover    % 上海交通大学硕士论文模板封面
 % ]
 
 % 逐个导入参考文献数据库

--- a/thesis.tex
+++ b/thesis.tex
@@ -4,7 +4,7 @@
 %%==================================================
 
 % 双面打印
-\documentclass[master, openright, twoside]{sjtuthesis}
+\documentclass[doctor, openright, twoside]{sjtuthesis}
 % \documentclass[bachelor, openany, oneside, submit]{sjtuthesis}
 % \documentclass[master, review]{sjtuthesis}
 % \documentclass[%


### PR DESCRIPTION
1.根据[上交硕士论文模板](http://gse.sjtu.edu.cn/gsecms/UpFiles/Article/201611221351336181.doc)添加了新的中英文封面，**通过altcover选项来使用**，与原有格式不冲突。
2.添加论文题目至 “原创性声明”页。
3.修改中英文摘要为4号字体(上面的模板是4号)。

效果图：
![image](https://user-images.githubusercontent.com/22615736/50903297-5fe48480-1458-11e9-81c2-24e4c91ba6ae.png)
![image](https://user-images.githubusercontent.com/22615736/50903318-6d9a0a00-1458-11e9-8738-3649664973c1.png)
![image](https://user-images.githubusercontent.com/22615736/50903333-78ed3580-1458-11e9-9ad9-1ae7ddc56bcd.png)
