### PR TITLE
modifysubctionfont

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -241,7 +241,7 @@
     afterskip    = {1.0ex \@plus .2ex},
   },
   subsection={%
-    format       = \zihao{-4}\normalfont,
+    format       = \zihao{-4}\bfseries\heiti,
     afterindent  = true,
     afterskip    = {1.0ex \@plus .2ex},
   },


### PR DESCRIPTION
### subsection字体修改
根据**上海交通大学博士、硕士学位论文撰写指南**（https://www.gs.sjtu.edu.cn/info/1143/5801.htm )
> 1．字号字体：一级标题用三号粗黑体；二级标题用四号粗黑体；三级标题用小四号粗黑体。正文用小四号或五号宋体。

其中的三级标题为subsection，master分支字体不对，现改成了小四号黑体。