### PR TITLE
Use unicode “□” (U+25A1) in Declaration of Authorization

### DIFF
--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -294,13 +294,7 @@
 \captionsetup[bi-first]{bi-first}
 \captionsetup[bi-second]{bi-second}
 \captionsetup[sub]{font=sjtusubcaptionfont}
-\newcommand{\sjtu@square}{%
-  \ifsjtu@unsetfont
-    {$\square$}
-  \else
-    \raisebox{-0.125ex}{\scalebox{1.5}{$\square$}}
-  \fi
-}
+\newcommand{\sjtu@square}{{\CJKfamily+{zhsong}\symbol{"25A1}}}
 \newcommand{\sjtu@authconf}{%
   \par\hspace{7em}%
   {\heiti 保\quad 密}~\sjtu@square，在 \uline{\hspace{3em}}

--- a/sjtuthesis.dtx
+++ b/sjtuthesis.dtx
@@ -1249,13 +1249,7 @@ The Current Maintainer of this work is Alexara Wu.
 % 支持扫描文件替换。
 %    \begin{macrocode}
 %<*class>
-\newcommand{\sjtu@square}{%
-  \ifsjtu@unsetfont
-    {$\square$}
-  \else
-    \raisebox{-0.125ex}{\scalebox{1.5}{$\square$}}
-  \fi
-}
+\newcommand{\sjtu@square}{{\CJKfamily+{zhsong}\symbol{"25A1}}}
 \newcommand{\sjtu@authconf}{%
   \par\hspace{7em}%
   {\heiti 保\quad 密}~\sjtu@square，在 \uline{\hspace{3em}}


### PR DESCRIPTION
版权授权书中的选项框现使用的是数学字体的 `$square$` ，但是 `newtx` 字体包的 `$square$` 太小了，看起来不协调。又发现中文字体基本都有“□” 这个字符，干脆直接使用中文字体的“□”了，