### PR TITLE
[feature] Add bool option support for `\sjtusetup'

### DIFF
--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -30,6 +30,9 @@
 \newcommand\sjtu@error[1]{%
   \ClassError{sjtuthesis}{#1}{}%
 }
+\newcommand\sjtu@warning[1]{%
+  \ClassWarning{sjtuthesis}{#1}{}%
+}
 \RequirePackage{kvdefinekeys}
 \RequirePackage{kvsetkeys}
 \RequirePackage{kvoptions}
@@ -43,7 +46,7 @@
 \newcommand\sjtu@define@key[2]{%
   \kvsetkeys{#1@key}{#2}%
 }
-\newcommand\sjtu@set@family@handler[1]{%
+\newcommand\sjtu@set@family@key@handler[1]{%
   \kv@set@family@handler{#1@key}{%
     \@namedef{#1@##1@@name}{##1}%
     \def\sjtu@@default{}%
@@ -92,10 +95,42 @@
     }%
   }
 }
+\newcommand\sjtu@define@bool[2]{%
+  \kvsetkeys{#1@bool}{#2}%
+}
+\newcommand\sjtu@set@family@bool@handler[1]{%
+  \kv@set@family@handler{#1@bool}{%
+    \@namedef{#1@##1@@name}{##1}%
+    \@namedef{#1@##1@@init}{false}%
+    \kv@define@key{#1@value}{name}{%
+      \@namedef{#1@##1@@name}{####1}%
+    }%
+    \kv@define@key{#1@value}{init}{%
+      \@namedef{#1@##1@@init}{####1}%
+    }%
+    \@namedef{#1@##1@@code}{}%
+    \kvsetkeys{#1@value}{##2}%
+    \expandafter\newif\csname if#1@\@nameuse{#1@##1@@name}\endcsname
+    \@nameuse{#1@\@nameuse{#1@##1@@name}\@nameuse{#1@##1@@init}}%
+    \kv@define@key{#1}{##1}[true]{%
+      \@ifundefined{%
+        #1@\@nameuse{#1@##1@@name}####1%
+      }{%
+        \sjtu@warning{%
+          Cannot set boolean option to `####1',\MessageBreak
+          use `true' or `false', now using `\@nameuse{#1@##1@@init}'%
+        }%
+      }{%
+        \@nameuse{#1@\@nameuse{#1@##1@@name}####1}%
+      }
+      \@nameuse{#1@##1@@code}%
+    }%
+  }
+}
 \newcommand\sjtu@option@hook[3]{%
   \expandafter\g@addto@macro\csname #1@#2@@code\endcsname{#3}%
 }
-\sjtu@set@family@handler{sjtu}
+\sjtu@set@family@key@handler{sjtu}
 \sjtu@define@key{sjtu}{
   degree = {
     choices = {
@@ -196,7 +231,7 @@
 \kv@define@key{sjtu}{format}{
   \kvsetkeys{sjtu@format}{#1}
 }
-\sjtu@set@family@handler{sjtu@format}
+\sjtu@set@family@key@handler{sjtu@format}
 \sjtu@define@key{sjtu@format}{
   title-logo-color = {
     name = title@logo@color,
@@ -228,7 +263,7 @@
 \kv@define@key{sjtu}{info}{
   \kvsetkeys{sjtu@info}{#1}
 }
-\sjtu@set@family@handler{sjtu@info}
+\sjtu@set@family@key@handler{sjtu@info}
 \sjtu@define@key{sjtu@info}{
   title           = { name = title@zh },
   title*          = { name = title@en },
@@ -299,7 +334,7 @@
 \kv@define@key{sjtu}{name}{
   \kvsetkeys{sjtu@name}{#1}
 }
-\sjtu@set@family@handler{sjtu@name}
+\sjtu@set@family@key@handler{sjtu@name}
 \sjtu@define@key{sjtu@name}{
   appendix          = { default = Appendix },
   contents          = { default = Contents },
@@ -622,7 +657,7 @@
 }
 \sjtu@load@fontset
 \sjtu@option@hook{sjtu}{latinfontset}{%
-  \sjtu@load@math@font
+  \sjtu@load@fontset
 }
 \def\sjtu@thepage{}
 \def\sjtu@lastpageref{}

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -63,7 +63,7 @@
         \@ifundefined{%
           if#1@\@nameuse{#1@##1@@name}@\@nameuse{#1@\@nameuse{#1@##1@@name}}%
         }{%
-          \sjtu@error{Invalid value "##1 = \@nameuse{#1@\@nameuse{#1@##1@@name}}"}%
+          \sjtu@error{Invalid value `##1 = \@nameuse{#1@\@nameuse{#1@##1@@name}}'}%
         }%
         \@nameuse{#1@##1@@reset}%
         \@nameuse{#1@\@nameuse{#1@##1@@name}@\@nameuse{#1@\@nameuse{#1@##1@@name}}true}%
@@ -117,7 +117,7 @@
         #1@\@nameuse{#1@##1@@name}####1%
       }{%
         \sjtu@warning{%
-          Cannot set boolean option to `####1',\MessageBreak
+          Cannot set boolean option `##1' to `####1',\MessageBreak
           use `true' or `false', now using `\@nameuse{#1@##1@@init}'%
         }%
       }{%

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -260,6 +260,10 @@
     default = {--},
   },
 }
+\sjtu@set@family@bool@handler{sjtu@format}
+\sjtu@define@bool{sjtu@format}{
+  indent-headings = { name = indent@headings },
+}
 \kv@define@key{sjtu}{info}{
   \kvsetkeys{sjtu@info}{#1}
 }
@@ -737,7 +741,7 @@
   \@mainmatterfalse
 }
 \ctexset{%
-  chapter={%
+  chapter = {%
     format       = \zihao{3}\bfseries\heiti\centering,
     nameformat   = {},
     titleformat  = {},
@@ -746,27 +750,56 @@
     beforeskip   = 1ex,
     afterskip    = 2ex
   },
-  section={%
+  section = {%
     format       = \zihao{4}\bfseries\heiti,
     afterindent  = true,
     afterskip    = 1ex \@plus .2ex
   },
-  subsection={%
+  subsection = {%
     format       = \zihao{-4}\bfseries\heiti,
     afterindent  = true,
     afterskip    = 1ex \@plus .2ex
   },
-  subsubsection={%
+  subsubsection = {%
     format       = \zihao{-4}\normalfont,
     afterindent  = true,
     afterskip    = 1ex \@plus .2ex
   },
   paragraph/afterindent    = true,
-  subparagraph/afterindent = true}
+  subparagraph/afterindent = true,
+}
+\newcommand\sjtu@format@set@indent@headings{%
+  \ifsjtu@format@indent@headings
+    \ctexset{%
+      section/indent       = 2\ccwd,
+      subsection/indent    = 2\ccwd,
+      subsubsection/indent = 2\ccwd,
+    }
+    \ifsjtu@degree@graduate\relax\else
+      \ctexset{%
+        subsubsection/name   = {(,)},
+        subsubsection/number = \arabic{subsubsection},
+      }
+    \fi
+  \else
+    \ctexset{%
+      section/indent       = 0pt,
+      subsection/indent    = 0pt,
+      subsubsection/indent = 0pt,
+      subsubsection/name   = {},
+      subsubsection/number = \thesubsubsection,
+    }
+  \fi
+}
+\sjtu@format@set@indent@headings
+\sjtu@option@hook{sjtu@format}{indent-headings}{%
+  \sjtu@format@set@indent@headings
+}
 \ctexset{%
   punct          = quanjiao,
   space          = auto,
-  autoindent     = true}
+  autoindent     = true,
+}
 \AtEndOfClass{\sloppy}
 \setlist{nosep}
 \setlist*{leftmargin=*}


### PR DESCRIPTION
#### Features
- 使 `\sjtusetup` 支持使用布尔型选项。
- 新增布尔型选项 `format/indent-headings`，控制节标题是否缩进，启用为 `true`，默认为 `false`；
```latex
\sjtusetup{
  format={
    indent-headings,
    % 也可以使用 <key>=<value> 形式
    % indent-headings = true,
    header-logo-color = red,
  },
}
```
#### Related Issues
#422 #514