### PR TITLE
Add `fixed' option for `indent-headings'

### DIFF
--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -219,6 +219,7 @@
     choices = {
       true,
       false,
+      fixed,
     },
     initial = false,
     default = true,
@@ -876,12 +877,20 @@
   paragraph/afterindent    = true,
   subparagraph/afterindent = true,
 }
+\newlength{\sjtu@indent@headings@fixed@width}
+\setlength{\sjtu@indent@headings@fixed@width}{2\ccwd}
 \newcommand\sjtu@format@set@indent@headings{%
+  \ifsjtu@format@indent@headings@fixed
+    \sjtu@format@indent@headings@truetrue
+    \def\sjtu@indent@headings@width{\sjtu@indent@headings@fixed@width}
+  \else
+    \def\sjtu@indent@headings@width{2\ccwd}
+  \fi
   \ifsjtu@format@indent@headings@true
     \ctexset{%
-      section/indent       = 2\ccwd,
-      subsection/indent    = 2\ccwd,
-      subsubsection/indent = 2\ccwd,
+      section/indent       = \sjtu@indent@headings@width,
+      subsection/indent    = \sjtu@indent@headings@width,
+      subsubsection/indent = \sjtu@indent@headings@width,
     }
     \ifsjtu@degree@graduate\relax\else
       \ctexset{%


### PR DESCRIPTION
`indent-headings` 新增选项 `fixed`，节标题使用统一的缩进距离。


| `indent-headings=fixed` | `indent-headings=true` |
|--|--|
| ![1](https://user-images.githubusercontent.com/15205102/82749092-7e42ea00-9dd9-11ea-95fd-fb94196277c7.png) | ![2](https://user-images.githubusercontent.com/15205102/82749100-86028e80-9dd9-11ea-9a21-43a8ebe61ed4.png) |

手头有一本同济的《高等数学》也是这样排版的。我猜学校要求的本意应该也是用统一缩进，不过给 Word 模版没调好。@LuminousXLB 
![Screen Shot 2020-05-24 at 16 22 39](https://user-images.githubusercontent.com/15205102/82749323-05449200-9ddb-11ea-935d-d19b8f44faa5.png)


