### PR TITLE
添加博士后出站报告模板以及博士的预答辩模式选项

### DIFF
--- a/bibdata/thesis.bib
+++ b/bibdata/thesis.bib
@@ -260,3 +260,13 @@
   title        = {R: A Language and Environment for Statistical Computing},
 }
 
+@article{jiang2008reflections,
+  title={Reflections on energy issues in China},
+  author={Jiang, Ze-min},
+  journal={Journal of Shanghai Jiaotong University (Science)},
+  volume={13},
+  number={3},
+  pages={257--274},
+  year={2008},
+  publisher={Springer}
+}

--- a/contents/publications.tex
+++ b/contents/publications.tex
@@ -1,11 +1,14 @@
 % !TEX root = ../main.tex
 
 \begin{publications}
-  \item Chen H, Chan C~T. Acoustic cloaking in three dimensions using acoustic metamaterials[J]. Applied Physics Letters, 2007, 91:183518.
-  \item Chen H, Wu B~I, Zhang B, et al. Electromagnetic Wave Interactions with a Metamaterial Cloak[J]. Physical Review Letters, 2007, 99(6):63903.
+	\begin{refsection}
+		\nocite{jiang2008reflections,Meta_CN,JohnD}
+		\printbibliography[heading=none]
+	\end{refsection}
 \end{publications}
 
 \begin{publications*}
-  \item 第一作者. 中文核心期刊论文, 2007.
-  \item 第一作者. EI 国际会议论文, 2006.
+	\item 第一作者. 上海交通大学学报, 2008.
+	\item 第一作者. 中文核心期刊论文, 2007.
+	\item 第一作者. EI 国际会议论文, 2006.
 \end{publications*}

--- a/contents/publications.tex
+++ b/contents/publications.tex
@@ -1,11 +1,22 @@
 % !TEX root = ../main.tex
 
-\begin{publications}
+% 如果用biblatex，可自动生成发表论文
+% 如果不用biblatex，请注释以下publications环境
+\begin{publications}[biblatex]
 	\begin{refsection}
+		% 在nocite中添加发表的论文
 		\nocite{jiang2008reflections,chen2007act,chen2007ewi}
 		\printbibliography[heading=none]
 	\end{refsection}
 \end{publications}
+
+% 如果不用biblatex，请取消注释以下publications环境
+% 并手工填写发表论文
+% \begin{publications}
+% 	\item Jiang Z~M. Reflections on energy issues in China[J]. Journal of Shanghai Jiaotong University (Science), 2008, 13(3): 257-274.
+% 	\item Chen H, Chan C~T. Acoustic cloaking in three dimensions using acoustic metamaterials[J]. Applied Physics Letters, 2007, 91:183518.
+% 	\item Chen H, Wu B~I, Zhang B, et al. Electromagnetic Wave Interactions with a Metamaterial Cloak[J]. Physical Review Letters, 2007, 99(6):63903.
+% \end{publications}
 
 \begin{publications*}
 	\item 第一作者. 上海交通大学学报, 2008.

--- a/contents/publications.tex
+++ b/contents/publications.tex
@@ -2,24 +2,28 @@
 
 % 如果用biblatex，可自动生成发表论文
 % 如果不用biblatex，请注释以下publications环境
-\begin{publications}[biblatex]
-	\begin{refsection}
-		% 在nocite中添加发表的论文
-		\nocite{jiang2008reflections,chen2007act,chen2007ewi}
-		\printbibliography[heading=none]
-	\end{refsection}
+\begin{publications}[{攻读学位期间发表（或录用）的学术论文}]
+    % 博士后将可选参数改为
+    % 博士生期间发表的学术论文、专著
+    % 及
+    % 博士后期间发表的学术论文、专著
+    \begin{refsection}
+        % 在nocite中添加发表的论文
+        \nocite{jiang2008reflections,chen2007act,chen2007ewi}
+        \printbibliography[heading=none]
+    \end{refsection}
 \end{publications}
 
 % 如果不用biblatex，请取消注释以下publications环境
 % 并手工填写发表论文
 % \begin{publications}
-% 	\item Jiang Z~M. Reflections on energy issues in China[J]. Journal of Shanghai Jiaotong University (Science), 2008, 13(3): 257-274.
-% 	\item Chen H, Chan C~T. Acoustic cloaking in three dimensions using acoustic metamaterials[J]. Applied Physics Letters, 2007, 91:183518.
-% 	\item Chen H, Wu B~I, Zhang B, et al. Electromagnetic Wave Interactions with a Metamaterial Cloak[J]. Physical Review Letters, 2007, 99(6):63903.
+%   \item Jiang Z~M. Reflections on energy issues in China[J]. Journal of Shanghai Jiaotong University (Science), 2008, 13(3): 257-274.
+%   \item Chen H, Chan C~T. Acoustic cloaking in three dimensions using acoustic metamaterials[J]. Applied Physics Letters, 2007, 91:183518.
+%   \item Chen H, Wu B~I, Zhang B, et al. Electromagnetic Wave Interactions with a Metamaterial Cloak[J]. Physical Review Letters, 2007, 99(6):63903.
 % \end{publications}
 
 \begin{publications*}
-	\item 第一作者. 上海交通大学学报, 2008.
-	\item 第一作者. 中文核心期刊论文, 2007.
-	\item 第一作者. EI 国际会议论文, 2006.
+    \item 第一作者. 上海交通大学学报, 2008.
+    \item 第一作者. 中文核心期刊论文, 2007.
+    \item 第一作者. EI 国际会议论文, 2006.
 \end{publications*}

--- a/contents/publications.tex
+++ b/contents/publications.tex
@@ -2,7 +2,7 @@
 
 \begin{publications}
 	\begin{refsection}
-		\nocite{jiang2008reflections,Meta_CN,JohnD}
+		\nocite{jiang2008reflections,chen2007act,chen2007ewi}
 		\printbibliography[heading=none]
 	\end{refsection}
 \end{publications}

--- a/main.tex
+++ b/main.tex
@@ -3,7 +3,7 @@
 % 载入 SJTUThesis 模版
 \documentclass[type=master]{sjtuthesis}
 % 选项
-%   type=[doctor|master|bachelor|course],     % 可选（默认：doctor），论文类型
+%   type=[postdoctor|doctor|master|bachelor|course],     % 可选（默认：doctor），论文类型
 %   zihao=[-4|5],                             % 可选（研究生默认：-4，本科默认：5），正文字号大小
 %   language=[chinese|english],               % 可选（默认：chinese），论文的主要语言
 %   review,                                   % 可选（默认：关闭），盲审模式

--- a/main.tex
+++ b/main.tex
@@ -7,6 +7,7 @@
 %   zihao=[-4|5],                             % 可选（研究生默认：-4，本科默认：5），正文字号大小
 %   language=[chinese|english],               % 可选（默认：chinese），论文的主要语言
 %   review,                                   % 可选（默认：关闭），盲审模式
+%   predefence,                               % 可选（默认：关闭），预答辩模式
 %   [twoside|oneside]                         % 可选（默认：twoside），单双页模式
 
 % 论文基本配置，加载宏包等全局配置

--- a/sjtusetup.tex
+++ b/sjtusetup.tex
@@ -78,6 +78,14 @@
     %           {National Basic Research Program of China (Grant No. 2025CB000000)},
     %           {National Natural Science Foundation of China (Grant No. 81120250000)},
     %         },
+    %
+    % 以下为博士后模板参数
+    %
+    % discipline      = {一级学科},
+    % subdiscipline   = {二级学科},
+    %
+    % begindate       = {2018-11-11},
+    % enddate         = {2020-12-12},
   },
   %
   % 风格设置

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis-postdoctor.ltx
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis-postdoctor.ltx
@@ -116,8 +116,8 @@
       \zihao{4}
       \def\arraystretch{1.25}
       \begin{tabular}
-        {>{\begin{CJKfilltwosides}[t]{9.5\ccwd}\heiti}r<{\end{CJKfilltwosides}}
-          @{：}l}
+        {>{\begin{CJKfilltwosides}[t]{11.5\ccwd}\heiti}r<{\end{CJKfilltwosides}}
+          @{　}l}
         \sjtu@name@author@zh           & \sjtu@info@author            \\
         \sjtu@name@discipline@zh       & \sjtu@info@discipline@zh     \\
         \sjtu@name@subdiscipline@zh    & \sjtu@info@subdiscipline@zh  \\
@@ -130,7 +130,7 @@
       \def\arraystretch{1.25}
       \begin{tabular}
         {>{\begin{CJKfilltwosides}[t]{8.5\ccwd}\heiti}r<{\end{CJKfilltwosides}}
-          @{：}l}
+          @{　}l}
         \sjtu@name@begindate@zh        &
           \sjtu@date{\sjtu@date@format@zh}{\sjtu@info@begindate}      \\
         \sjtu@name@enddate@zh          &
@@ -140,7 +140,7 @@
     \endgroup
     \vskip \stretch{3}
     \sjtu@name@school@zh\par
-    \sjtu@date{\sjtu@date@format@zh}{\sjtu@info@date}
+    \sjtu@date{\sjtu@date@yearmonthformat@zh}{\sjtu@info@date}
     \vskip 26pt
   \end{center}
 }

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis-postdoctor.ltx
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis-postdoctor.ltx
@@ -1,0 +1,149 @@
+%%
+%% This is file `sjtuthesis-postdoctor.ltx',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% sjtuthesis.dtx  (with options: `postdoctor')
+%% 
+%% Copyright (C) 2009-2017 by weijianwen <weijianwen@gmail.com>
+%%           (C) 2018-2020 by SJTUG
+%% 
+%% This file may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3c
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%%     https://www.latex-project.org/lppl.txt
+%% and version 1.3c or later is part of all distributions of LaTeX
+%% version 2005/12/01 or later.
+%% 
+%% This file has the LPPL maintenance status "maintained".
+%% 
+%% The Current Maintainer of this work is Alexara Wu.
+%% 
+\ProvidesFile{sjtuthesis-postdoctor.ltx}
+  [2020/07/31 1.0.0rc7 Shanghai Jiao Tong University Thesis Template]
+\geometry{%
+  paper      = a4paper,
+  top        = 3.5cm,
+  bottom     = 4.0cm,
+  left       = 3.3cm,
+  right      = 2.8cm,
+  headheight = 1.0cm,
+  headsep    = 0.5cm,
+}
+\pagestyle{fancy}
+\newcommand\sjtu@thepage@format[2]{---~{\bfseries{#1}}~---}
+\def\sjtu@info@fund{}
+\fancypagestyle{title}{%
+  \fancyhf{}
+  \fancyfoot[L]{\ifsjtu@review\relax\else\sjtu@info@fund\fi}
+  \renewcommand\headrulewidth{0pt}
+  \renewcommand\footrulewidth{0pt}
+}
+\fancypagestyle{plain}{%
+  \fancyhf{}
+  \ifsjtu@style@header@single
+    \fancyhead[C]{\zihao{-5}\sjtu@name@subject@zh}
+  \else
+    \fancyhead[RE,LO]{\zihao{-5}\sjtu@name@subject@zh}
+    \fancyhead[RO,LE]{\zihao{-5}\leftmark}
+  \fi
+  \fancyfoot[C]{%
+    \ifsjtu@page@numbering
+      \zihao{-5}\sjtu@thepage@format{\sjtu@thepage}{\sjtu@lastpageref}%
+    \fi
+  }
+  \renewcommand\headrule{%
+    \hrule\@height2.25pt\@width\headwidth
+    \vskip 0.75pt
+    \hrule\@height0.75pt\@width\headwidth
+    \vskip-3.75pt
+  }
+}
+\renewcommand\cftchapfont{\bfseries\heiti}
+\renewcommand\cftchapleader{\normalfont\cftdotfill{\cftdotsep}}
+\NewDocumentEnvironment{abstract}{}{%
+  \sjtu@chapter*[\sjtu@name@abstract@zh]{%
+    \vskip 2ex
+    \begingroup
+      \sjtu@name@abstract@zh
+    \endgroup
+  }[\sjtu@name@abstract]%
+  \zihao{4}
+}{%
+  \vskip 3ex \noindent
+  \begingroup
+    \heiti\sjtu@name@keywords@zh
+  \endgroup
+  \begingroup
+    \sjtu@clist@use{\sjtu@info@keywords@zh}{，}
+  \endgroup
+}
+\NewDocumentEnvironment{abstract*}{}{%
+  \sjtu@chapter*[\sjtu@name@abstract@en]{%
+    \vskip 2ex
+    \begingroup
+      \MakeUppercase\sjtu@name@abstract@en
+    \endgroup
+  }[]
+  \zihao{4}
+}{%
+  \vskip 3ex \noindent
+  \begingroup
+    \bfseries\MakeUppercase
+    \sjtu@name@keywords@en
+  \endgroup
+  \begingroup
+    \sjtu@clist@use{\sjtu@info@keywords@en}{, }
+  \endgroup
+}
+\RenewDocumentCommand{\maketitle}{}{%
+  \sjtu@pdfbookmark{0}{\sjtu@name@titlepage}
+  \sjtu@make@titlepage%
+}
+\newcommand\sjtu@make@titlepage{%
+  \cleardoublepage
+  \def\sjtu@info@fund{\zihao{-5}\sjtu@clist@use{\sjtu@info@fund@zh}{\par}}
+  \thispagestyle{title}
+  \begin{center}
+    \vspace*{28pt}
+    {\zihao{2}\heiti\sjtu@info@title@zh\par}
+    \vskip \stretch{2}
+    {\zihao{2}\heiti\sjtu@info@title@en\par}
+    \vskip \stretch{2}
+    \begingroup
+      \zihao{4}
+      \def\arraystretch{1.25}
+      \begin{tabular}
+        {>{\begin{CJKfilltwosides}[t]{9.5\ccwd}\heiti}r<{\end{CJKfilltwosides}}
+          @{：}l}
+        \sjtu@name@author@zh           & \sjtu@info@author            \\
+        \sjtu@name@discipline@zh       & \sjtu@info@discipline@zh     \\
+        \sjtu@name@subdiscipline@zh    & \sjtu@info@subdiscipline@zh  \\
+      \end{tabular}
+      \par
+    \endgroup
+    \vskip \stretch{3}
+    \begingroup
+      \zihao{4}
+      \def\arraystretch{1.25}
+      \begin{tabular}
+        {>{\begin{CJKfilltwosides}[t]{8.5\ccwd}\heiti}r<{\end{CJKfilltwosides}}
+          @{：}l}
+        \sjtu@name@begindate@zh        &
+          \sjtu@date{\sjtu@date@format@zh}{\sjtu@info@begindate}      \\
+        \sjtu@name@enddate@zh          &
+          \sjtu@date{\sjtu@date@format@zh}{\sjtu@info@enddate}        \\
+      \end{tabular}
+      \par
+    \endgroup
+    \vskip \stretch{3}
+    \sjtu@name@school@zh\par
+    \sjtu@date{\sjtu@date@format@zh}{\sjtu@info@date}
+    \vskip 26pt
+  \end{center}
+}
+\endinput
+%%
+%% End of file `sjtuthesis-postdoctor.ltx'.

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -1172,9 +1172,10 @@
   \Collect@Body\sjtu@save@env@body
 }{%
   \ifsjtu@review\relax\else
-    \begin{sjtu@bibliolist}{#1}{\sjtu@name@publications}
+    % \begin{sjtu@bibliolist}{#1}{\sjtu@name@publications}
+      \sjtu@chapter{\sjtu@name@publications}
       \sjtu@saved@env@body
-    \end{sjtu@bibliolist}
+    % \end{sjtu@bibliolist}
   \fi
 }
 \NewDocumentEnvironment{publications*}{O{99}}{%

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -112,6 +112,7 @@
 \sjtu@define@key{sjtu}{
   type = {
     choices = {
+      postdoctor,
       doctor,
       master,
       bachelor,
@@ -154,6 +155,9 @@
 \ProcessKeyvalOptions*
 \newif\ifsjtu@type@graduate
 \sjtu@type@graduatefalse
+\ifsjtu@type@postdoctor
+  \sjtu@type@graduatetrue
+\fi
 \ifsjtu@type@doctor
   \sjtu@type@graduatetrue
 \fi
@@ -172,7 +176,11 @@
 \LoadClass[a4paper,UTF8,scheme=plain,linespread=1.3]{ctexbook}[2018/04/01]
 \AtEndOfClass{
   \ifsjtu@type@graduate
-    \input{sjtuthesis-graduate.ltx}
+    \ifsjtu@type@postdoctor
+      \input{sjtuthesis-postdoctor.ltx}
+    \else
+      \input{sjtuthesis-graduate.ltx}
+    \fi
   \else
     \input{sjtuthesis-undergraduate.ltx}
   \fi
@@ -304,6 +312,14 @@
   date            = {%
     initial = {\the\year-\two@digits{\month}-\two@digits{\day}},
   },
+  discipline      = { name = discipline@zh },
+  subdiscipline   = { name = subdiscipline@zh },
+  begindate       = {%
+    initial = {\the\year-\two@digits{\month}-\two@digits{\day}},
+  },
+  enddate         = {%
+    initial = {\the\year-\two@digits{\month}-\two@digits{\day}},
+  },
 }
 \newcommand\sjtu@nopar[1]{%
   \begingroup\let\\\@empty#1\endgroup%
@@ -376,40 +392,56 @@
 \sjtu@name@def{school@zh}{上海交通大学}
 \sjtu@name@def{school@en}{Shanghai Jiao Tong University}
 \ifsjtu@type@graduate
-  \ifsjtu@type@doctor
-    \sjtu@name@def{degree@type@zh}{博士}
-    \sjtu@name@def{degree@type@en}{Doctor}
+  \ifsjtu@type@postdoctor
+    \sjtu@name@def{author@zh}{博士后姓名}
+    \sjtu@name@def{discipline@zh}{流动站（一级学科）}
+    \sjtu@name@def{subdiscipline@zh}{专　业（二级学科）}
+    \sjtu@name@def{begindate@zh}{研究工作起始时间}
+    \sjtu@name@def{enddate@zh}{研究工作期满时间}
+    \sjtu@name@def{position@zh}{博士后}
+    \sjtu@name@def{thesis@type}{研究工作报告}
+    \sjtu@name@def{subject@zh}{%
+      \sjtu@name@school@zh\sjtu@name@position@zh\sjtu@name@thesis@type
+    }
+    \sjtu@name@def{subject@en}{%
+      \sjtu@name@school@zh\sjtu@name@position@zh\sjtu@name@thesis@type
+    }
   \else
-    \sjtu@name@def{degree@type@zh}{硕士}
-    \sjtu@name@def{degree@type@en}{Master}
+    \ifsjtu@type@doctor
+      \sjtu@name@def{degree@type@zh}{博士}
+      \sjtu@name@def{degree@type@en}{Doctor}
+    \else
+      \sjtu@name@def{degree@type@zh}{硕士}
+      \sjtu@name@def{degree@type@en}{Master}
+    \fi
+    \sjtu@name@def{author@zh}{\sjtu@name@degree@type@zh 研究生}
+    \sjtu@name@def{author@en}{Candidate}
+    \sjtu@name@def{id@zh}{学号}
+    \sjtu@name@def{id@en}{Student ID}
+    \sjtu@name@def{supervisor@zh}{导师}
+    \sjtu@name@def{supervisor@en}{Supervisor}
+    \sjtu@name@def{assisupervisor@zh}{副导师}
+    \sjtu@name@def{assisupervisor@en}{Assistant Supervisor}
+    \sjtu@name@def{degree@zh}{申请学位}
+    \sjtu@name@def{degree@en}{Academic Degree Applied for}
+    \sjtu@name@def{major@zh}{学科}
+    \sjtu@name@def{major@en}{Speciality}
+    \sjtu@name@def{department@zh}{所在单位}
+    \sjtu@name@def{department@en}{Affiliation}
+    \sjtu@name@def{defenddate@zh}{答辩日期}
+    \sjtu@name@def{defenddate@en}{Date of Defence}
+    \sjtu@name@def{conferring@zh}{授予学位单位}
+    \sjtu@name@def{conferring@en}{Degree-Conferring-Institution}
+    \sjtu@name@def{thesis@type}{学位论文}
+    \sjtu@name@def{thesis@kind}{\sjtu@name@thesis@type}
+    \sjtu@name@def{subject@zh}{%
+      \sjtu@name@school@zh\sjtu@name@degree@type@zh\sjtu@name@thesis@type
+    }
+    \sjtu@name@def{subject@en}{%
+      Dissertation Submitted to \sjtu@name@school@en \\
+      for the Degree of \sjtu@name@degree@type@en
+    }
   \fi
-  \sjtu@name@def{author@zh}{\sjtu@name@degree@type@zh 研究生}
-  \sjtu@name@def{author@en}{Candidate}
-  \sjtu@name@def{id@zh}{学号}
-  \sjtu@name@def{id@en}{Student ID}
-  \sjtu@name@def{supervisor@zh}{导师}
-  \sjtu@name@def{supervisor@en}{Supervisor}
-  \sjtu@name@def{assisupervisor@zh}{副导师}
-  \sjtu@name@def{assisupervisor@en}{Assistant Supervisor}
-  \sjtu@name@def{degree@zh}{申请学位}
-  \sjtu@name@def{degree@en}{Academic Degree Applied for}
-  \sjtu@name@def{major@zh}{学科}
-  \sjtu@name@def{major@en}{Speciality}
-  \sjtu@name@def{department@zh}{所在单位}
-  \sjtu@name@def{department@en}{Affiliation}
-  \sjtu@name@def{defenddate@zh}{答辩日期}
-  \sjtu@name@def{defenddate@en}{Date of Defence}
-  \sjtu@name@def{conferring@zh}{授予学位单位}
-  \sjtu@name@def{conferring@en}{Degree-Conferring-Institution}
-  \sjtu@name@def{thesis@type}{学位论文}
-  \sjtu@name@def{thesis@kind}{\sjtu@name@thesis@type}
-  \sjtu@name@def{subject@zh}{%
-    \sjtu@name@school@zh\sjtu@name@degree@type@zh\sjtu@name@thesis@type
-  }
-  \sjtu@name@def{subject@en}{%
-    Dissertation Submitted to \sjtu@name@school@en \\
-    for the Degree of \sjtu@name@degree@type@en
-  }
 \else
   \ifsjtu@type@course
     \sjtu@name@def{degree@type@zh}{}
@@ -1177,7 +1209,7 @@
         \sjtu@saved@env@body
       \end{sjtu@bibliolist}
     }{
-      \sjtu@chapter{\sjtu@name@publications}
+      \sjtu@chapter{#1}
       \sjtu@saved@env@body
     }
   \fi

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -356,6 +356,7 @@
   \fi
 }
 \newcommand\sjtu@date@format@zh[3]{#1 年 \number#2 月 \number#3 日}
+\newcommand\sjtu@date@yearmonthformat@zh[3]{#1 年 \number#2 月}
 \newcommand\sjtu@date@month@en[1]{%
   \ifcase\number#1\or
     January\or February\or March\or April\or May\or June\or
@@ -394,9 +395,9 @@
 \sjtu@name@def{school@en}{Shanghai Jiao Tong University}
 \ifsjtu@type@graduate
   \ifsjtu@type@postdoctor
-    \sjtu@name@def{author@zh}{博士后姓名}
-    \sjtu@name@def{discipline@zh}{流动站（一级学科）}
-    \sjtu@name@def{subdiscipline@zh}{专　业（二级学科）}
+    \sjtu@name@def{author@zh}{博士后姓名　　}
+    \sjtu@name@def{discipline@zh}{流动站（一级学科）名称}
+    \sjtu@name@def{subdiscipline@zh}{专　业（二级学科）名称}
     \sjtu@name@def{begindate@zh}{研究工作起始时间}
     \sjtu@name@def{enddate@zh}{研究工作期满时间}
     \sjtu@name@def{position@zh}{博士后}
@@ -492,15 +493,25 @@
   本人授权\sjtu@name@school@zh 可以将本\sjtu@name@thesis@kind 的全部或部
   分内容编入有关数据库进行检索，可以采用影印、缩印或扫描等复制手段保存和
   汇编本\sjtu@name@thesis@kind 。}
-\sjtu@name@def{abstract@zh}{摘\hspace{\ccwd}要}
+\ifsjtu@type@postdoctor
+  \sjtu@name@def{abstract@zh}{内\hspace{\ccwd}容\hspace{\ccwd}摘\hspace{\ccwd}要}
+\else
+  \sjtu@name@def{abstract@zh}{摘\hspace{\ccwd}要}
+\fi
 \sjtu@name@def{abstract@en}{Abstract}
 \sjtu@name@def{keywords@zh}{关键词：}
 \sjtu@name@def{keywords@en}{Key words:~}
 \ifsjtu@language@chinese
+  \ifsjtu@type@postdoctor
+    \sjtu@name@def{contents}{目\hspace{\ccwd}次}
+    \sjtu@name@def{nomenclature}{符号表}
+  \else
+    \sjtu@name@def{contents}{目\hspace{\ccwd}录}
+    \sjtu@name@def{nomenclature}{主要符号对照表}
+  \fi
   \sjtusetup{
     name = {
       appendix          = {附录},
-      contents          = {目\hspace{\ccwd}录},
       listfigure        = {插图索引},
       listtable         = {表格索引},
       listalgorithm     = {算法索引},
@@ -509,7 +520,6 @@
       table             = {表},
       table*            = {Table},
       algorithm         = {算法},
-      nomenclature      = {主要符号对照表},
       summary           = {全文总结},
       bib               = {参考文献},
       index             = {索\hspace{\ccwd}引},

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -1168,14 +1168,18 @@
     {\@latex@warning{Empty `bibliolist' environment}}%
   \endlist
 }
-\NewDocumentEnvironment{publications}{O{99}}{%
+\NewDocumentEnvironment{publications}{o O{99}}{%
   \Collect@Body\sjtu@save@env@body
 }{%
   \ifsjtu@review\relax\else
-    % \begin{sjtu@bibliolist}{#1}{\sjtu@name@publications}
+    \IfNoValueTF{#1}{
+      \begin{sjtu@bibliolist}{#2}{\sjtu@name@publications}
+        \sjtu@saved@env@body
+      \end{sjtu@bibliolist}
+    }{
       \sjtu@chapter{\sjtu@name@publications}
       \sjtu@saved@env@body
-    % \end{sjtu@bibliolist}
+    }
   \fi
 }
 \NewDocumentEnvironment{publications*}{O{99}}{%

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -150,6 +150,7 @@
   },
 }
 \DeclareBoolOption[false]{review}
+\DeclareBoolOption[false]{predefence}
 \DeclareBoolOption[false]{continuous}
 \DeclareDefaultOption{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessKeyvalOptions*
@@ -428,8 +429,13 @@
     \sjtu@name@def{major@en}{Speciality}
     \sjtu@name@def{department@zh}{所在单位}
     \sjtu@name@def{department@en}{Affiliation}
-    \sjtu@name@def{defenddate@zh}{答辩日期}
-    \sjtu@name@def{defenddate@en}{Date of Defence}
+    \ifsjtu@predefence
+      \sjtu@name@def{defenddate@zh}{预答辩日期}
+      \sjtu@name@def{defenddate@en}{Date of Pre-defence}
+    \else
+      \sjtu@name@def{defenddate@zh}{答辩日期}
+      \sjtu@name@def{defenddate@en}{Date of Defence}
+    \fi
     \sjtu@name@def{conferring@zh}{授予学位单位}
     \sjtu@name@def{conferring@en}{Degree-Conferring-Institution}
     \sjtu@name@def{thesis@type}{学位论文}


### PR DESCRIPTION
biblatex是支持多处输出参考文献的，故而已发表论文一章也可用biblatex处理。至于盲审版本则只能保留手工处理。增加了一个交大学报的文献，用于测试已发表论文中被引用而未在正文中引用的文献不会出现在参考文献中，只出现在已发表论文中。