### PR TITLE
Fix uline hspace conflict

### DIFF
--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -1054,7 +1054,7 @@
     \linespread{1}\selectfont
     本\sjtu@name@thesis@type 属于\parbox[c]{20\ccwd}{%
       {\heiti 保\hspace{1\ccwd}密}~\sjtu@square ，
-      在\uline{\hspace{2\ccwd}}年解密后适用本授权书。\bigbreak
+      在\underline{\hspace{2\ccwd}}年解密后适用本授权书。\bigbreak
       {\heiti 不保密}~\sjtu@square 。
     }\par
   \endgroup


### PR DESCRIPTION
Arch下新版本\uline和\hspace共存会编译错误
```
... Extra }, or forgotten \endgroup...
```
导致授权书无法生成

Ref: https://tex.stackexchange.com/questions/568732/uline-does-not-work-with-hspace