### PR TITLE
feat: fit abstract to undergraduate's need

### DIFF
--- a/sjtuthesis/doc/sample-master-cn.tex
+++ b/sjtuthesis/doc/sample-master-cn.tex
@@ -21,6 +21,10 @@
   \input{common-abstract-cn.tex}
 \end{abstract}
 
+\begin{abstract*}
+  \input{common-abstract-en.tex}
+\end{abstract*}
+
 % 目录
 \tableofcontents
 % 插图索引

--- a/sjtuthesis/doc/sample-undergraduate-cn.tex
+++ b/sjtuthesis/doc/sample-undergraduate-cn.tex
@@ -21,6 +21,10 @@
   \input{common-abstract-cn.tex}
 \end{abstract}
 
+\begin{abstract*}
+  \input{common-abstract-en.tex}
+\end{abstract*}
+
 % 目录
 \tableofcontents
 % 插图索引

--- a/sjtuthesis/source/sjtuthesis.dtx
+++ b/sjtuthesis/source/sjtuthesis.dtx
@@ -1195,6 +1195,58 @@
   }
 %    \end{macrocode}
 %
+% \subsection{绘制封面}
+%    \begin{macrocode}
+%<*(ug|pg)>
+\RenewDocumentCommand{\maketitle}{}{
+%<zh>  \SJTU@make@titlepage@zh
+%<en>  \SJTU@make@titlepage@en
+}
+%</(ug|pg)>
+%    \end{macrocode}
+% 绘制本科生英文封面
+%    \begin{macrocode}
+%<*ug>
+\newcommand\SJTU@make@titlepage@zh{
+  \cleardoublepage
+  \thispagestyle{empty}
+  这里什么也没有
+}
+%</ug>
+%    \end{macrocode}
+%
+% 绘制本科生英文封面
+%    \begin{macrocode}
+%<*ug>
+\newcommand\SJTU@make@titlepage@en{
+  \cleardoublepage
+  \thispagestyle{empty}
+  这里什么也没有
+}
+%</ug>
+%    \end{macrocode}
+%
+% 绘制研究生中文封面
+%    \begin{macrocode}
+%<*pg>
+\newcommand\SJTU@make@titlepage@zh{
+  \cleardoublepage
+  \thispagestyle{empty}
+  这里什么也没有
+}
+%</pg>
+%    \end{macrocode}
+%
+% 绘制研究生英文封面
+%    \begin{macrocode}
+%<*pg>
+\newcommand\SJTU@make@titlepage@en{
+  \cleardoublepage
+  \thispagestyle{empty}
+  这里什么也没有
+}
+%</pg>
+%    \end{macrocode}
 %
 % \subsection{页眉页脚}
 %
@@ -1294,20 +1346,34 @@
 %    \end{macrocode}
 %
 % \subsection{摘要}
+% “摘要”为四号黑字体居中(摘要后空一行)，摘要内容为五号宋体字，首行缩进二个字，单倍行距;
+% 摘要内容后空一行顶格输入“关键词”(小四号黑体字)，其后为关键词(五号宋体字)，各关键词之间用逗
+% 号分开，最后一个关键词后面无标点符号。
 %
+% 英文“ABSTRACT”为四号 Times New Roman 居中加黑, 摘要内容为五号 Times New Roman，首行缩进二个字，
+% 单倍行距;“Key words”小四号 Times New Roman 加黑，顶格书写，关键词五号 Times New Roman，
+% 各关键词之间逗号分开。中英文摘要不需编页码。
 %    \begin{macrocode}
 \DeclareDocumentEnvironment { abstract  } { }
   { \SJTU@chapter* { \c_@@_name_abstract_zh_tl } [ \c_@@_name_abstract_tl ] }
   {
     \par \mode_leave_vertical: \par \noindent
-    { \heiti    \c_@@_name_keywords_zh_tl }
+    { 
+      \heiti
+%<ug>  \zihao{-4}
+      \c_@@_name_keywords_zh_tl 
+    }
     \clist_use:Nn \l_@@_info_keywords_zh_clist { ， }
   }
 \DeclareDocumentEnvironment { abstract* } { }
   { \SJTU@chapter* { \c_@@_name_abstract_en_tl } [ ] }
   {
     \par \mode_leave_vertical: \par \noindent
-    { \bfseries \c_@@_name_keywords_en_tl }
+    { 
+      \bfseries
+%<ug>  \zihao{-4}
+      \c_@@_name_keywords_en_tl 
+    }
     \clist_use:Nn \l_@@_info_keywords_en_clist { ,~ }
   }
 %    \end{macrocode}
@@ -1380,7 +1446,7 @@
   }
 \clist_map_inline:nn
   { 
-    { abstract } { 摘 \quad 要 } { Abstract    } ,
+    { abstract } { 摘 \quad 要 } { ABSTRACT    } ,
     { keywords } { 关键词：    } { Key~words:~ }
   }
   { \@@_define_name:nnn #1 }

--- a/sjtuthesis/support/common-setup-cn.tex
+++ b/sjtuthesis/support/common-setup-cn.tex
@@ -1,3 +1,85 @@
-\title{SJTUThesis 示例模版}
-\author{SJTUG}
-\date{\zhtoday}
+\sjtusetup{
+  %
+  %******************************
+  % 注意：
+  %   1. 配置里面不要出现空行
+  %   2. 不需要的配置信息可以删除
+  %******************************
+  %
+  % 信息录入
+  %
+  info = {%
+      %
+      % 标题
+      %
+      title           = {上海交通大学学位论文 \LaTeX{} 模板示例文档},
+      title*          = {A Sample Document for \LaTeX-based SJTU Thesis Template},
+      %
+      % 标题页标题
+      %   可使用“\\”命令手动控制换行
+      %
+      display-title   = {上海交通大学学位论文\\ \LaTeX{} 模板示例文档},
+      display-title*  = {A Sample Document \\ for \LaTeX-based SJTU Thesis Template},
+      %
+      % 页眉标题
+      %
+      running-title   = {示例文档},
+      running-title*  = {Sample Document},
+      %
+      % 关键词
+      %
+      keywords        = {上海交大, 饮水思源, 爱国荣校},
+      keywords*       = {SJTU, master thesis, XeTeX/LaTeX template},
+      %
+      % 姓名
+      %
+      author          = {某\quad{}某},
+      author*         = {Mo Mo},
+      %
+      % 指导教师
+      %
+      supervisor      = {某某教授},
+      supervisor*     = {Prof. Mou Mou},
+      %
+      % 学号
+      %
+      id              = {0010900990},
+      %
+      % 学位
+      %   本科生不需要填写
+      %
+      degree          = {工学硕士},
+      degree*         = {Master of Engineering},
+      %
+      % 专业
+      %
+      major           = {某某专业},
+      major*          = {A Very Important Major},
+      %
+      % 所属院系
+      %
+      department      = {某某系},
+      department*     = {Depart of XXX},
+      %
+      % 课程名称
+      %   仅课程论文适用
+      %
+      % course          = {某某课程},
+      %
+      % 答辩日期
+      %   使用 ISO 格式 (yyyy-mm-dd)；默认为当前时间
+      %
+      % date            = {2014-12-17},
+      %
+      % 资助基金
+      %
+      % fund  = {
+      %           {国家 973 项目 (No. 2025CB000000)},
+      %           {国家自然科学基金 (No. 81120250000)},
+      %         },
+      % fund* = {
+      %           {National Basic Research Program of China (Grant No. 2025CB000000)},
+      %           {National Natural Science Foundation of China (Grant No. 81120250000)},
+      %         },
+    }
+}

--- a/sjtuthesis/support/common-setup-en.tex
+++ b/sjtuthesis/support/common-setup-en.tex
@@ -1,3 +1,85 @@
-\title{SJTUThesis 示例模版}
-\author{SJTUG}
-\date{\today}
+\sjtusetup{
+  %
+  %******************************
+  % 注意：
+  %   1. 配置里面不要出现空行
+  %   2. 不需要的配置信息可以删除
+  %******************************
+  %
+  % 信息录入
+  %
+  info = {%
+      %
+      % 标题
+      %
+      title           = {上海交通大学学位论文 \LaTeX{} 模板示例文档},
+      title*          = {A Sample Document for \LaTeX-based SJTU Thesis Template},
+      %
+      % 标题页标题
+      %   可使用“\\”命令手动控制换行
+      %
+      display-title   = {上海交通大学学位论文\\ \LaTeX{} 模板示例文档},
+      display-title*  = {A Sample Document \\ for \LaTeX-based SJTU Thesis Template},
+      %
+      % 页眉标题
+      %
+      running-title   = {示例文档},
+      running-title*  = {Sample Document},
+      %
+      % 关键词
+      %
+      keywords        = {上海交大, 饮水思源, 爱国荣校},
+      keywords*       = {SJTU, master thesis, XeTeX/LaTeX template},
+      %
+      % 姓名
+      %
+      author          = {某\quad{}某},
+      author*         = {Mo Mo},
+      %
+      % 指导教师
+      %
+      supervisor      = {某某教授},
+      supervisor*     = {Prof. Mou Mou},
+      %
+      % 学号
+      %
+      id              = {0010900990},
+      %
+      % 学位
+      %   本科生不需要填写
+      %
+      degree          = {工学硕士},
+      degree*         = {Master of Engineering},
+      %
+      % 专业
+      %
+      major           = {某某专业},
+      major*          = {A Very Important Major},
+      %
+      % 所属院系
+      %
+      department      = {某某系},
+      department*     = {Depart of XXX},
+      %
+      % 课程名称
+      %   仅课程论文适用
+      %
+      % course          = {某某课程},
+      %
+      % 答辩日期
+      %   使用 ISO 格式 (yyyy-mm-dd)；默认为当前时间
+      %
+      % date            = {2014-12-17},
+      %
+      % 资助基金
+      %
+      % fund  = {
+      %           {国家 973 项目 (No. 2025CB000000)},
+      %           {国家自然科学基金 (No. 81120250000)},
+      %         },
+      % fund* = {
+      %           {National Basic Research Program of China (Grant No. 2025CB000000)},
+      %           {National Natural Science Foundation of China (Grant No. 81120250000)},
+      %         },
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

这个 PR 加入了一些新功能：

* 测试文档的数据都使用 `\sjtusetup` 录入。
* 测试文档同时包含中英文摘要。
* 先做了一个 titlepage 的 placeholder，里面没有内容。
* 根据本科生模版要求更新了摘要的格式。

考虑到 https://github.com/sjtug/SJTUThesis/discussions/705 关于开发方式的问题还在讨论，我们可以先 review 这个 PR，之后再决定合并到 SJTUTeX 还是这个仓库。