### PR TITLE
feat: use xelatex in latexmk

### DIFF
--- a/Compile.bat
+++ b/Compile.bat
@@ -55,7 +55,7 @@ goto :EOF
 
 :thesis
 	echo %ESC%[33mCompile . . .%ESC%[0m
-	latexmk -quiet -file-line-error -halt-on-error -interaction=nonstopmode %THESIS% 2>nul
+	latexmk -quiet -xelatex -file-line-error -halt-on-error -interaction=nonstopmode %THESIS% 2>nul
 goto :EOF
 
 :clean

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 THESIS = main
 
 # Option for latexmk
-LATEXMK_OPT = -quiet -file-line-error -halt-on-error -interaction=nonstopmode
+LATEXMK_OPT = -quiet -xelatex -file-line-error -halt-on-error -interaction=nonstopmode
 LATEXMK_OPT_PVC = $(LATEXMK_OPT) -pvc
 
 # make deletion work on Windows


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

最近有不少用户反馈 latexmk 没有默认使用 latexmkrc 中 pdf_mode 指定的 xelatex 编译器，所以我们把这个参数加到 compile.bat 里面了。

Ref https://github.com/sjtug/SJTUThesis/discussions/735