### PR TITLE
feat: add v2 build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ build/
 
 SJTUTeX-v1/
 SJTUTeX-v2/
+dev-v2.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ thesis-bot.yml
 build/
 
 SJTUTeX-v1/
+SJTUTeX-v2/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 THESIS = main
 
 # Option for latexmk
-LATEXMK_OPT = -quiet -file-line-error -halt-on-error -interaction=nonstopmode
+LATEXMK_OPT = -time -file-line-error -halt-on-error -interaction=nonstopmode
 LATEXMK_OPT_PVC = $(LATEXMK_OPT) -pvc
 
 # make deletion work on Windows

--- a/build_v2.sh
+++ b/build_v2.sh
@@ -2,9 +2,14 @@
 
 set -e
 
-# Before running this script, clone v2 of SJTUTeX into project root
+SJTUTEX_DIR="SJTUTeX-v2"
 
-cd SJTUTeX && make generate && cd ..
+if [ ! -d "${SJTUTEX_DIR}" ]; then
+    git clone https://github.com/sjtug/SJTUTeX -b v2 ${SJTUTEX_DIR}
+fi
+
+cd ${SJTUTEX_DIR} && make generate && cd ..
 rm -rf texmf/tex/latex/sjtuthesis
-ln -s $(pwd)/SJTUTeX/sjtuthesis/build/unpacked texmf/tex/latex/sjtuthesis
-make
+ln -s $(pwd)/${SJTUTEX_DIR}/sjtuthesis/build/unpacked texmf/tex/latex/sjtuthesis
+
+latexmk dev-v2.tex -xelatex -time -file-line-error -halt-on-error -interaction=nonstopmode

--- a/build_v2.sh
+++ b/build_v2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Before running this script, clone v2 of SJTUTeX into project root
+
+cd SJTUTeX && make generate && cd ..
+rm -rf texmf/tex/latex/sjtuthesis
+ln -s $(pwd)/SJTUTeX/sjtuthesis/build/unpacked texmf/tex/latex/sjtuthesis
+make

--- a/dev-v2.tex
+++ b/dev-v2.tex
@@ -1,0 +1,199 @@
+% !TeX encoding = UTF-8
+
+% 这个模版是 SJTUTeX v2 的测试模版。如果您是 SJTUThesis 示例模版的用户，请无视这个文件。
+
+% 载入 SJTUThesis 模版
+\documentclass[type=bachelor]{sjtuthesis}
+
+\sjtusetup{
+  info = {
+    title           = {上海交通大学学位论文 \LaTeX{} 模板示例文档},
+    title*          = {A Sample Document for \LaTeX-based SJTU Thesis Template},
+    % display-title   = {上海交通大学学位论文\\ \LaTeX{} 模板示例文档},
+    % display-title*  = {A Sample Document \\ for \LaTeX-based SJTU Thesis Template},
+    % running-title   = {示例文档},
+    % running-title*  = {Sample Document},
+    keywords        = {上海交大, 饮水思源, 爱国荣校},
+    keywords*       = {SJTU, master thesis, XeTeX/LaTeX template},
+    author          = {某\quad{}某},
+    author*         = {Mo Mo},
+    supervisor      = {某某教授},
+    supervisor*     = {Prof. Mou Mou},
+    assoc-supervisor  = {某某教授},
+    assoc-supervisor* = {Prof. Uom Uom},
+    id              = {0010900990},
+    degree          = {工学硕士},
+    degree*         = {Master of Engineering},
+    major           = {某某专业},
+    major*          = {A Very Important Major},
+    department      = {某某系},
+    department*     = {Depart of XXX},
+  },
+  style = {
+    header-logo-color = blue,
+    title-logo-color = blue,
+  },
+}
+
+% 使用 BibLaTeX 处理参考文献
+%   biblatex-gb7714-2015 常用选项
+%     gbnamefmt=lowercase     姓名大小写由输入信息确定
+%     gbpub=false             禁用出版信息缺失处理
+\usepackage[backend=biber,style=gb7714-2015]{biblatex}
+% 文献表字体
+% \renewcommand{\bibfont}{\zihao{-5}}
+% 文献表条目间的间距
+\setlength{\bibitemsep}{0pt}
+% 导入参考文献数据库
+\addbibresource{bibdata/thesis.bib}
+
+% 定义图片文件目录与扩展名
+\graphicspath{{figures/}}
+\DeclareGraphicsExtensions{.pdf,.eps,.png,.jpg,.jpeg}
+
+% 确定浮动对象的位置，可以使用 [H]，强制将浮动对象放到这里（可能效果很差）
+% \usepackage{float}
+
+% 固定宽度的表格
+% \usepackage{tabularx}
+
+% 表格中支持跨行
+\usepackage{multirow}
+
+% 表格中数字按小数点对齐
+\usepackage{dcolumn}
+\newcolumntype{d}[1]{D{.}{.}{#1}}
+
+% 使用长表格
+\usepackage{longtable}
+
+% 附带脚注的表格
+\usepackage{threeparttable}
+
+% 附带脚注的长表格
+\usepackage{threeparttablex}
+
+% 算法环境宏包
+\usepackage[ruled,vlined,linesnumbered]{algorithm2e}
+% \usepackage{algorithm, algorithmicx, algpseudocode}
+
+% 代码环境宏包
+\usepackage{listings}
+\lstnewenvironment{codeblock}[1][]%
+  {\lstset{style=lstStyleCode,#1}}{}
+
+% 物理科学和技术中使用的数学符号，定义了 \qty 命令，与 siunitx 3.0 有冲突
+% \usepackage{physics}
+
+% 直立体数学符号
+\newcommand{\dd}{\mathop{}\!\mathrm{d}}
+\newcommand{\ee}{\mathrm{e}}
+\newcommand{\ii}{\mathrm{i}}
+\newcommand{\jj}{\mathrm{j}}
+
+% 国际单位制宏包
+\usepackage{siunitx}[=v2]
+
+% 定理环境宏包
+\usepackage{ntheorem}
+% \usepackage{amsthm}
+
+% 绘图宏包
+\usepackage{tikz}
+\usetikzlibrary{shapes.geometric, arrows}
+
+% 一些文档中用到的 logo
+\usepackage{hologo}
+\newcommand{\XeTeX}{\hologo{XeTeX}}
+\newcommand{\BibLaTeX}{\textsc{Bib}\LaTeX}
+
+% 借用 ltxdoc 里面的几个命令方便写文档
+\DeclareRobustCommand\cs[1]{\texttt{\char`\\#1}}
+\providecommand\pkg[1]{{\sffamily#1}}
+
+% 自定义命令
+
+% E-mail
+\newcommand{\email}[1]{\href{mailto:#1}{\texttt{#1}}}
+
+% hyperref 宏包在最后调用
+\usepackage{hyperref}
+
+\begin{document}
+
+%TC:ignore
+
+% 标题页
+\maketitle
+
+% 原创性声明及使用授权书
+% \copyrightpage
+% 插入外置原创性声明及使用授权书
+% \copyrightpage[scans/sample-copyright-old.pdf]
+
+% 前置部分
+\frontmatter
+
+% 摘要
+\input{contents/abstract}
+
+% 目录
+\tableofcontents
+% 插图索引
+\listoffigures*
+% 表格索引
+\listoftables*
+% 算法索引
+\listofalgorithms*
+
+% 符号对照表
+% \input{contents/nomenclature}
+
+%TC:endignore
+
+% 主体部分
+\mainmatter
+
+% 正文内容
+\input{contents/intro}
+% \input{contents/math_and_citations}
+% \input{contents/floats}
+% \input{contents/summary}
+
+%TC:ignore
+
+% 参考文献
+\printbibliography[heading=bibintoc]
+
+% 附录
+\appendix
+
+% 附录中图表不加入索引
+\captionsetup{list=no}
+
+% 附录内容
+\input{contents/app_maxwell_equations}
+\input{contents/app_flow_chart}
+
+% 结尾部分
+\backmatter
+
+% 用于盲审的论文需隐去致谢、发表论文、科研成果、简历
+
+% 致谢
+% \input{contents/acknowledgements}
+
+% 发表论文、科研成果
+% 盲审论文中，发表论文及科研成果等仅以第几作者注明即可，不要出现作者或他人姓名
+% \input{contents/publications}
+% \input{contents/achievements}
+
+% 简历
+% \input{contents/resume}
+
+% 学士学位论文要求在最后有一个大摘要，单独编页码
+\input{contents/digest}
+
+%TC:endignore
+
+\end{document}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

最近在尝试用 SJTUTeX v2 编译现在的示例文档，这个 PR 添加了一个简单的 `build.sh`，可以方便开发过程。

在使用 `build_v2.sh` 之前，开发者应该将 SJTUTeX v2 clone 到项目根目录。

而后，运行 `./build_v2.sh`，这个脚本会先从 dtx 生成 sty 等文件，而后将 texmf 目录下的 sjtuthesis 文件夹替换成 SJTUTeX v2 生成的文件，最后编译示例文档。

由于 SJTUTeX v2 砍掉了部分功能，现在示例文档还不能编译通过，之后会修复（