### PR TITLE
docs:update VSCode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://mirror.sjtu.edu.cn/git/SJTUThesis.git/
 
 ### VSCode 用户
 
-安装 “LaTeX Workshop” 后，选择 `Recipe: latexmk (xelatex)` 编译即可，并在设置中将 `latex-workshop.latex.recipe.default` 改为 `LastUsed` 以一直使用该选项编译。
+安装 “LaTeX Workshop” 后，选择 `Recipe: latexmk (xelatex)` 编译即可，并在设置中将 `latex-workshop.latex.recipe.default` 改为 `lastUsed` 以一直使用该选项编译。
 
 ### TexStudio 用户
 


### PR DESCRIPTION
fix a typo.`lastused` requires the first letter to be lowercase.

Note there are two particular values:

first means to use the first recipe in Latex-workshop › Latex: Recipes;
lastUsed means to use the last run recipe.