### PR TITLE
feat: add support for minted package

### DIFF
--- a/contents/floats.tex
+++ b/contents/floats.tex
@@ -328,7 +328,7 @@ int main() {
 若要使用更美观以及支持代码高亮的 \pkg{minted} 宏包，请确保 \texttt{PATH} 中包含 \texttt{pygmentize} 命令，并参考下面注释掉的内容及 \pkg{minted} 宏包文档。
 
 % \begin{listing}[!hpt]
-%   \caption{代码示例}
+%   \bicaption{代码示例}{Code Example}
 %   \label{code:codelisting}
 %   \begin{minted}{python}
 %     def hello():

--- a/contents/floats.tex
+++ b/contents/floats.tex
@@ -292,8 +292,9 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 \section{代码环境}
 
-我们可以在论文中插入算法，但是不建议插入大段的代码。如果确实需要插入代码，建议使
-用 \pkg{listings} 宏包。
+我们可以在论文中插入算法，但是不建议插入大段的代码。如果确实需要插入代码，可以使用 \pkg{listings} 或 \pkg{minted} 宏包。
+
+下面展示了使用 \pkg{listings} 宏包的代码块例子：
 
 \begin{codeblock}[language=C]
 #include <stdio.h>
@@ -323,3 +324,14 @@ int main() {
   return 0;
 }
 \end{codeblock}
+
+若要使用更美观以及支持代码高亮的 \pkg{minted} 宏包，请确保 \texttt{PATH} 中包含 \texttt{pygmentize} 命令，并参考下面注释掉的内容及 \pkg{minted} 宏包文档。
+
+% \begin{listing}[!hpt]
+%   \caption{代码示例}
+%   \label{code:codelisting}
+%   \begin{minted}{python}
+%     def hello():
+%         foo = bar()
+%   \end{minted}
+% \end{listing}

--- a/setup.tex
+++ b/setup.tex
@@ -124,6 +124,9 @@
 \graphicspath{{figures/}}
 \DeclareGraphicsExtensions{.pdf,.eps,.png,.jpg,.jpeg}
 
+% 子 figure 支持
+% \usepackage{subcaption}
+
 % 确定浮动对象的位置，可以使用 [H]，强制将浮动对象放到这里（可能效果很差）
 % \usepackage{float}
 
@@ -156,7 +159,22 @@
 % 代码环境宏包
 \usepackage{listings}
 \lstnewenvironment{codeblock}[1][]%
-  {\lstset{style=lstStyleCode,#1}}{}
+{\lstset{style=lstStyleCode,#1}}{}
+% 代码高亮（需要 PATH 中包含 pygmentize 命令）
+\usepackage[chapter,newfloat]{minted}
+% 调整代码清单标题和标号
+\renewcommand{\thelisting}{\thechapter-\arabic{listing}}
+\captionsetup[listing]{name={代码清单}}
+% 设置 minted 环境显示效果
+\setminted{autogobble,baselinestretch=1,breaklines,frame=lines,framesep=3mm,style=vs,stripnl,tabsize=4}
+% 移除 minted 环境前后过多空白
+\let\oldminted\minted
+\def\minted{\vspace{-0.4cm}\oldminted}
+\let\oldendminted\endminted
+\def\endminted{\oldendminted\vspace{-0.4cm}}
+
+% 允许 text 模式直接使用下划线，从而可以写 \texttt{foo_bar} 而无需 \texttt{foo\_bar}
+% \usepackage{underscore}
 
 % 物理科学和技术中使用的数学符号，定义了 \qty 命令，与 siunitx 3.0 有冲突
 % \usepackage{physics}
@@ -211,3 +229,4 @@
 \def\subparagraphautorefname{子段落}
 \def\FancyVerbLineautorefname{行}
 \def\theoremautorefname{定理}
+\def\listingautorefname{代码清单}

--- a/setup.tex
+++ b/setup.tex
@@ -156,19 +156,10 @@
 % 代码环境宏包
 \usepackage{listings}
 \lstnewenvironment{codeblock}[1][]%
-{\lstset{style=lstStyleCode,#1}}{}
-% 代码高亮（需要 PATH 中包含 pygmentize 命令）
-\usepackage[chapter,newfloat]{minted}
-% 调整代码清单标题和标号
-\renewcommand{\thelisting}{\thechapter-\arabic{listing}}
-\captionsetup[listing]{name={代码清单}}
-% 设置 minted 环境显示效果
-\setminted{autogobble,baselinestretch=1,breaklines,frame=lines,framesep=3mm,style=vs,stripnl,tabsize=4}
-% 移除 minted 环境前后过多空白
-\let\oldminted\minted
-\def\minted{\vspace{-0.4cm}\oldminted}
-\let\oldendminted\endminted
-\def\endminted{\oldendminted\vspace{-0.4cm}}
+  {\lstset{style=lstStyleCode,#1}}{}
+
+% 代码高亮宏包（需要 PATH 中包含 pygmentize 命令，且构建环境允许添加 -shell-escape 参数）
+% \usepackage{minted}
 
 % 物理科学和技术中使用的数学符号，定义了 \qty 命令，与 siunitx 3.0 有冲突
 % \usepackage{physics}

--- a/setup.tex
+++ b/setup.tex
@@ -124,9 +124,6 @@
 \graphicspath{{figures/}}
 \DeclareGraphicsExtensions{.pdf,.eps,.png,.jpg,.jpeg}
 
-% 子 figure 支持
-% \usepackage{subcaption}
-
 % 确定浮动对象的位置，可以使用 [H]，强制将浮动对象放到这里（可能效果很差）
 % \usepackage{float}
 
@@ -172,9 +169,6 @@
 \def\minted{\vspace{-0.4cm}\oldminted}
 \let\oldendminted\endminted
 \def\endminted{\oldendminted\vspace{-0.4cm}}
-
-% 允许 text 模式直接使用下划线，从而可以写 \texttt{foo_bar} 而无需 \texttt{foo\_bar}
-% \usepackage{underscore}
 
 % 物理科学和技术中使用的数学符号，定义了 \qty 命令，与 siunitx 3.0 有冲突
 % \usepackage{physics}

--- a/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
+++ b/texmf/tex/latex/sjtuthesis/sjtuthesis.cls
@@ -5,10 +5,10 @@
 %% The original source files were:
 %%
 %% sjtuthesis.dtx  (with options: `class')
-%% 
+%%
 %% Copyright (C) 2009-2017 by weijianwen <weijianwen@gmail.com>
 %%           (C) 2018-2022 by SJTUG
-%% 
+%%
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
 %% of this license or (at your option) any later version.
@@ -16,11 +16,11 @@
 %%     https://www.latex-project.org/lppl.txt
 %% and version 1.3c or later is part of all distributions of LaTeX
 %% version 2005/12/01 or later.
-%% 
+%%
 %% This file has the LPPL maintenance status "maintained".
-%% 
+%%
 %% The Current Maintainer of this work is Alexara Wu.
-%% 
+%%
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{sjtuthesis}
   [2022/07/29 1.1.1 Shanghai Jiao Tong University Thesis Template]
@@ -407,6 +407,8 @@
   figure*           = { name = figure@second, initial = 图 },
   table             = { initial = Table },
   table*            = { name = table@second, initial = 表 },
+  listing           = { initial = Listing },
+  listing*          = { name = listing@second, initial = 代码清单 },
   algorithm         = { initial = Algorithm },
   abbr              = { initial = Abbreviation },
   nom               = { initial = Nomenclature },
@@ -507,6 +509,8 @@
       figure*           = {Figure},
       table             = {表},
       table*            = {Table},
+      listing           = {代码清单},
+      listing*          = {Listing},
       algorithm         = {算法},
       abbr              = {缩略语对照表},
       nom               = {符号对照表},
@@ -848,6 +852,7 @@
   \def\thefigure{\thechapter\sjtu@style@fl@num@sep\arabic{figure}}
   \def\p@subfigure{\thefigure}
   \def\thetable{\thechapter\sjtu@style@fl@num@sep\arabic{table}}
+  \def\thelisting{\thechapter\sjtu@style@fl@num@sep\arabic{listing}}
   \def\theequation{\thechapter\sjtu@style@eq@num@sep\arabic{equation}}
 }
 \newcommand\sjtu@counter@without@chapter{
@@ -857,6 +862,8 @@
   \setcounter{figure}{0}
   \counterwithout{table}{chapter}
   \setcounter{table}{0}
+  \counterwithout{listing}{chapter}
+  \setcounter{listing}{0}
 }
 \newif\ifsjtu@set@float@fontsize \sjtu@set@float@fontsizefalse
 \sjtu@patchcmd\@floatboxreset%
@@ -1323,6 +1330,19 @@
     texcl=true,
     mathescape=true
   }
+}
+\PassOptionsToPackage{chapter,newfloat}{minted}
+\AtEndOfPackageFile*{minted}{
+  \captionsetup[listing]{name=\sjtu@name@listing}
+  \captionsetup[listing][bi-first]{name=\sjtu@name@listing}
+  \captionsetup[listing][bi-second]{name=\sjtu@name@listing@second}
+  % Set the display style of minted enviroment
+  \setminted{autogobble,baselinestretch=1,breaklines,frame=lines,framesep=3mm,style=vs,stripnl,tabsize=4}
+  % Remove redundant vertical space around minted listings
+  \let\oldminted\minted
+  \def\minted{\vspace{-0.4cm}\oldminted}
+  \let\oldendminted\endminted
+  \def\endminted{\oldendminted\vspace{-0.4cm}}
 }
 \endinput
 %%


### PR DESCRIPTION
Signed-off-by: Richard Chien <stdrc@outlook.com>

在 `setup.tex` 中添加了一些对 `minted` 宏包的配置，使可以通过下面 TeX 添加带有代码高亮的“代码清单”浮动体：

```tex
\begin{listing}[!hpt]
  \caption{代码示例}
  \label{code:codelisting}
  \begin{minted}{python}
    def hello():
        foo = bar()
  \end{minted}
\end{listing}
```

效果图：

<img width="364" alt="截屏2022-11-12 17 56 05" src="https://user-images.githubusercontent.com/5317095/201468859-a77cf61a-b3c9-412a-aa69-1067fb054d14.png">

由于 `minted` 环境依赖 Pygments，没安装的话无法编译论文，所以示例里面把使用样例注释掉并添加了相关提醒。