### PR TITLE
fix: fix regex in wordcount

### DIFF
--- a/Compile.bat
+++ b/Compile.bat
@@ -77,7 +77,7 @@ goto :EOF
 	set found=0
 	setlocal enabledelayedexpansion
 
-	findstr "\\documentclass\[[^\[]*lang\s*=\s*en" %THESIS%.tex > nul
+	findstr \R \C:"\\documentclass\[[^\[]*lang *= *en" %THESIS%.tex > nul
 	if %errorlevel% equ 0 (
 		for /f "delims=" %%i in ('texcount %THESIS%.tex -inc -char-only  2^>nul') do (
 			if !found! equ 1 (

--- a/Compile.bat
+++ b/Compile.bat
@@ -77,7 +77,7 @@ goto :EOF
 	set found=0
 	setlocal enabledelayedexpansion
 
-	findstr "\\documentclass\[[^\[]*en" %THESIS%.tex > nul
+	findstr "\\documentclass\[[^\[]*lang\s*=\s*en" %THESIS%.tex > nul
 	if %errorlevel% equ 0 (
 		for /f "delims=" %%i in ('texcount %THESIS%.tex -inc -char-only  2^>nul') do (
 			if !found! equ 1 (

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ view : $(THESIS).pdf
 	$(OPEN) $<
 
 wordcount : $(THESIS).tex
-	@if grep -v ^% $< | grep -q '\\documentclass\[[^\[]*en'; then \
+	@if grep -v ^% $< | grep -q '\\documentclass\[[^\[]*lang\s*=\s*en'; then \
 		texcount $< -inc -char-only | awk '/total/ {getline; print "英文字符数\t\t\t:",$$4}'; \
 	else \
 		texcount $< -inc -ch-only   | awk '/total/ {getline; print "纯中文字数\t\t\t:",$$4}'; \


### PR DESCRIPTION
The original regex will match `openany` or `openright` option incorrectly.