### PR TITLE
docs: update bibfont optional setup

### DIFF
--- a/setup.tex
+++ b/setup.tex
@@ -109,7 +109,7 @@
 %     gbpub=false             禁用出版信息缺失处理
 \usepackage[backend=biber,style=gb7714-2015]{biblatex}
 % 文献表字体
-% \renewcommand{\bibfont}{\zihao{-5}}
+% \renewcommand{\bibfont}{\zihao{5}\fixedlineskip{15.6bp}}
 % 文献表条目间的间距
 \setlength{\bibitemsep}{0pt}
 % 导入参考文献数据库


### PR DESCRIPTION
更新注释中的参考文献字号，并设定为适合小五字号的固定行间距 15.6 磅。Close #957 