### PR TITLE
chore: add txs magic comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,21 @@ git clone https://mirror.sjtu.edu.cn/git/SJTUThesis.git/
 
 ## 模板使用
 
-如果你不熟悉 LaTeX 的编译流程，请**不要**直接使用编译器进行编译。针对不同的平台，模版提供了相应的编译脚本。在编译前，需要安装最新的 TeXLive 发行版。
+如果你不熟悉 LaTeX 的编译流程，请参考以下说明编译文档。在编译前，需要安装最新的 TeXLive 发行版。
 
-### VSCode 用户
+### 使用编辑器
 
-安装 “LaTeX Workshop” 后，选择 `Recipe: latexmk (xelatex)` 编译即可，并在设置中将 `latex-workshop.latex.recipe.default` 改为 `lastUsed` 以一直使用该选项编译。
+#### VS Code
 
-### Linux 与 macOS 用户
+安装 “LaTeX Workshop” 扩展，选择预设配方 `Recipe: latexmk (xelatex)` 编译即可；也可以在设置中将 `latex-workshop.latex.recipe.default` 改为 `latexmk (xelatex)` 将其设置为默认选项。
+
+#### TeXstudio
+
+模板内置 TeXstudio 魔术注释，可开箱即用。
+
+### 使用脚本
+
+#### Linux 与 macOS
 
 推荐使用模版提供的 `Makefile` 进行编译，具体来说我们提供了如下几条可用的命令：
 
@@ -54,7 +62,7 @@ make cleanall                 # 删除 main.pdf 和所有中间文件
 make wordcount                # 论文字数统计
 ```
 
-### Windows 用户
+#### Windows
 
 对于 Windows 用户，我们也提供了编译脚本 `Compile.bat`。可以双击直接编译，也可以在命令提示符窗口中使用脚本提供的额外功能：
 
@@ -65,7 +73,7 @@ make wordcount                # 论文字数统计
 .\Compile.bat wordcount       # 论文字数统计
 ```
 
-更多关于模板的实现细节以及使用信息，请查看使用文档 `sjtuthesis.pdf`。
+更多关于模板的实现细节以及使用信息，请查看使用文档 [`sjtutex.pdf`](https://mirrors.sjtug.sjtu.edu.cn/ctan/macros/latex/contrib/sjtutex/sjtutex.pdf)。
 
 ## 反馈与贡献
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SJTUThesis 示例模板
 
 [![Build Status](https://github.com/sjtug/SJTUThesis/actions/workflows/build.yml/badge.svg)](https://github.com/sjtug/SJTUThesis/actions)
-[![SJTUTeX](https://img.shields.io/github/v/release/sjtug/SJTUTeX?label=SJTUTeX)](https://github.com/sjtug/SJTUTeX) 
+[![SJTUTeX](https://img.shields.io/github/v/release/sjtug/SJTUTeX?label=SJTUTeX)](https://github.com/sjtug/SJTUTeX)
 [![Join Discussions](https://img.shields.io/github/discussions/sjtug/SJTUThesis)](https://github.com/sjtug/SJTUThesis/discussions)
 
 ## 欢迎使用上海交通大学论文模板
@@ -42,24 +42,6 @@ git clone https://mirror.sjtu.edu.cn/git/SJTUThesis.git/
 ### VSCode 用户
 
 安装 “LaTeX Workshop” 后，选择 `Recipe: latexmk (xelatex)` 编译即可，并在设置中将 `latex-workshop.latex.recipe.default` 改为 `lastUsed` 以一直使用该选项编译。
-
-### TeXStudio 用户
-
-在TexStudio的菜单栏中，Options-Configure TeXstudio界面中，修改以下两处：
-
-Commands-Latexmk一项修改为`latexmk -silent -synctex=1 -xelatex %`
-
-Build-Default Compiler一项修改为`txs:///latexmk`
-
-<details>
-
-<summary>展开配置</summary>
-
-<img src="https://user-images.githubusercontent.com/84025388/142163308-3d31f905-af78-40cb-bff1-851cdab04c87.png" width=500px/>
-
-<img src="https://user-images.githubusercontent.com/84025388/142163346-63ec7b7e-932f-44c5-90c4-3b35e435545d.png" width=500px/>
-
-</details>
 
 ### Linux 与 macOS 用户
 

--- a/README_en-US.md
+++ b/README_en-US.md
@@ -1,7 +1,7 @@
 # Sample Template of SJTUThesis
 
 [![Build Status](https://github.com/sjtug/SJTUThesis/actions/workflows/build.yml/badge.svg)](https://github.com/sjtug/SJTUThesis/actions)
-[![SJTUTeX](https://img.shields.io/github/v/release/sjtug/SJTUTeX?label=SJTUTeX)](https://github.com/sjtug/SJTUTeX) 
+[![SJTUTeX](https://img.shields.io/github/v/release/sjtug/SJTUTeX?label=SJTUTeX)](https://github.com/sjtug/SJTUTeX)
 [![Join Discussions](https://img.shields.io/github/discussions/sjtug/SJTUThesis)](https://github.com/sjtug/SJTUThesis/discussions)
 
 ## Welcome to LaTeX thesis template for Shanghai Jiao Tong University
@@ -17,7 +17,7 @@ Please note that `sjtuthesis` supports both XeTeX and LuaTeX engine, `sjtuthesis
 You can `clone` this repository directly or download it from [GitHub](https://github.com/sjtug/SJTUThesis).
 
 ```bash
-git clone https://github.com/sjtug/SJTUThesis.git 
+git clone https://github.com/sjtug/SJTUThesis.git
 ```
 
 ### Online LaTeX Editor
@@ -30,7 +30,21 @@ You can create your own project through the link above.
 
 ## Usage
 
-### Linux & macOS Users
+If you are not familiar with the LaTeX compilation process, please follow the instructions below to compile the document. Before compiling, you need to install the latest TeXLive distribution.
+
+### Compile with Editors
+
+#### VS Code
+
+Install the "LaTeX Workshop" extension, select the preset recipe `Recipe: latexmk (xelatex)` to compile; you can also change `latex-workshop.latex.recipe.default` to `latexmk (xelatex)` in the settings to set it as the default option.
+
+#### TeXstudio
+
+The template has built-in TeXstudio magic comments, can be used out of the box.
+
+### Compile with Scripts
+
+#### Linux & macOS
 
 It is recommended to use GNU make utility with `Makefile` provided in the template.
 
@@ -41,7 +55,7 @@ make cleanall                 # remove everything produced by make all
 make wordcount                # count the words of the thesis
 ```
 
-### Windows Users
+#### Windows
 
 We also provided a batch script `Compile.bat` for Windows users. You can double-click the batch file to compile instantly, or use it in Command Prompt to access extra features.
 
@@ -51,6 +65,8 @@ We also provided a batch script `Compile.bat` for Windows users. You can double-
 .\Compile.bat cleanall        # remove everything produced by make all
 .\Compile.bat wordcount       # count the words of the thesis
 ```
+
+For more information about the implementation and usage of the template, please refer to the document [`sjtutex.pdf`](https://mirrors.sjtug.sjtu.edu.cn/ctan/macros/latex/contrib/sjtutex/sjtutex.pdf).
 
 ## Feedback
 

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,6 @@
 % !TeX encoding = UTF-8
+% !TeX TXS-program:compile = txs:///latexmk/{-pdf} -xelatex
+% !TeX TXS-program:recompile-bibliography = txs:///latexmk/{} -v
 
 % 载入 SJTUThesis 模版
 \documentclass[type=master]{sjtuthesis}


### PR DESCRIPTION
添加 TeXstudio 魔术注释[^txs-af-ahu][^txs-ct-acbs]，无需修改 TeXstudio  设置，可开箱即用。

[^txs-af-ahu]: https://texstudio-org.github.io/advanced.html#advanced-header-usage
[^txs-ct-acbs]: https://texstudio-org.github.io/configuration.html#advanced-configuration-of-the-build-system

TeXstudio 默认的执行逻辑：如果需要生成参考文献，则先执行 `txs:///recompile-bibliography`，再执行 `txs:///compile`；
`txs:///recompile-bibliography` 的默认值为 `txs:///compile | txs:///bibliography | txs:///compile`。

由于 `latexmk` 可以自动处理参考文献，所以将 `txs:///compile` 设置为 `txs:///latexmk` 时，`txs:///recompile-bibliography` 的步骤不再必要，因此将其修改为 `latexmk -v`，不执行实际操作。

暂时移除了 README 中关于 TeXstudio 设置的介绍。