### PR TITLE
fix: wordcount findstr command args

### DIFF
--- a/Compile.bat
+++ b/Compile.bat
@@ -77,7 +77,7 @@ goto :EOF
 	set found=0
 	setlocal enabledelayedexpansion
 
-	findstr \R \C:"\\documentclass\[[^\[]*lang *= *en" %THESIS%.tex > nul
+	findstr /R /C:"\\documentclass\[[^\[]*lang *= *en" %THESIS%.tex > nul
 	if %errorlevel% equ 0 (
 		for /f "delims=" %%i in ('texcount %THESIS%.tex -inc -char-only  2^>nul') do (
 			if !found! equ 1 (


### PR DESCRIPTION
修复 Windows 脚本 Compile.bat 中的 `findstr` 命令参数，应当统一使用 `/` 设定参数（而不是 `\`），[官方文档](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/findstr)。

现有的脚本会产生 #1069 中的 `FINDSTR: Cannot open \C:\\documentclass` 错误。