### PR TITLE
Set texcl and mathescape to false by default

### DIFF
--- a/setup.tex
+++ b/setup.tex
@@ -174,8 +174,8 @@
   backgroundcolor   = \color{gray!10},
   columns           = flexible,
   keepspaces        = true,
-  texcl             = true,
-  mathescape        = true
+  % texcl             = true,  % 代码中的注释部分将会被视为 LaTeX 正文模式内容
+  % mathescape        = true,  % 代码中 $..$ 部分将会被视为 LaTeX 数学模式内容
 }
 \lstnewenvironment{codeblock}[1][]{%
   \lstset{style=lstStyleCode,#1}}{}

--- a/setup.tex
+++ b/setup.tex
@@ -175,7 +175,7 @@
   columns           = flexible,
   keepspaces        = true,
   % texcl             = true,  % 代码中的注释部分将会被视为 LaTeX 正文模式内容
-  % mathescape        = true,  % 代码中 $..$ 部分将会被视为 LaTeX 数学模式内容
+  % mathescape        = true,  % 代码中$..$的部分将会被视为 LaTeX 数学模式内容
 }
 \lstnewenvironment{codeblock}[1][]{%
   \lstset{style=lstStyleCode,#1}}{}


### PR DESCRIPTION
采纳 [水源社区帖子中的建议](https://shuiyuan.sjtu.edu.cn/t/topic/149287/414)，将 `codeblock` 的参数 `texcl` 和 `mathescape` 默认设置为 false，并添加注释说明。